### PR TITLE
[feat] Adiciona feedback visual para o status de salvamento no editor

### DIFF
--- a/frontend/src/pages/Editor/index.tsx
+++ b/frontend/src/pages/Editor/index.tsx
@@ -5,16 +5,20 @@ import { notaService } from "@/services/notaService"
 import debounce from "lodash.debounce"
 import axios from "axios"
 import type { DebouncedFunc } from "lodash"
+import { Check, LoaderCircle, X } from "lucide-react"
 
 const BR_COLORS = ["#009c3b", "#ffdf00", "#002776"]
 const INACTIVITY_TIMEOUT = 2000
 const AUTO_SAVE_DELAY = 1000
+
+type SaveStatus = "idle" | "saving" | "saved" | "error"
 
 export default function Editor() {
   const { key } = useParams<{ key: string }>()
   const [text, setText] = useState("")
   const [isTyping, setIsTyping] = useState(false)
   const [caretIndex, setCaretIndex] = useState(0)
+  const [saveStatus, setSaveStatus] = useState<SaveStatus>("idle")
   const typingTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null)
 
   useEffect(() => {
@@ -65,7 +69,11 @@ export default function Editor() {
       debounce((slug: string, content: string) => {
         notaService
           .upsert(slug, content)
-          .catch((err) => console.error("Falha ao salvar no banco:", err))
+          .then(() => setSaveStatus("saved"))
+          .catch((err) => {
+            setSaveStatus("error")
+            console.error("Falha ao salvar no banco:", err)
+          })
       }, AUTO_SAVE_DELAY),
     []
   )
@@ -86,7 +94,10 @@ export default function Editor() {
       setIsTyping(false)
     }, INACTIVITY_TIMEOUT)
 
-    if (key) saveToBackend(key, newText)
+    if (key) {
+      setSaveStatus("saving")
+      saveToBackend(key, newText)
+    }
   }
 
   useEffect(() => {
@@ -96,12 +107,33 @@ export default function Editor() {
 
   return (
     <div className="w-full h-screen bg-background">
+      {saveStatus !== "idle" && (
+        <div
+          aria-live="polite"
+          className={`pointer-events-none fixed right-5 top-4 z-10 flex items-center gap-1.5 text-sm ${
+            saveStatus === "error" ? "text-destructive" : "text-foreground/55"
+          }`}
+        >
+          {saveStatus === "saving" ? (
+            <LoaderCircle aria-hidden="true" className="size-4 animate-spin opacity-60" />
+          ) : saveStatus === "saved" ? (
+            <Check aria-hidden="true" className="size-4 stroke-[3] opacity-60" />
+          ) : (
+            <X aria-hidden="true" className="size-4 stroke-[3] opacity-60" />
+          )}
+          {saveStatus === "saving"
+            ? "Salvando…"
+            : saveStatus === "saved"
+              ? "Salvo"
+              : "Erro ao salvar"}
+        </div>
+      )}
       <Textarea
         value={text}
         onChange={handleChange}
         placeholder={`Escrevendo em: ${key}`}
         autoFocus
-        className="w-full h-full resize-none border-none rounded-none font-mono text-[18px] leading-6 p-5 focus-visible:ring-0 focus-visible:ring-offset-0 placeholder:text-muted-foreground/40 [scrollbar-width:thin] [scrollbar-color:hsl(var(--border))_transparent]"
+        className="w-full h-full resize-none border-none rounded-none p-5 pt-14 font-mono text-[18px] leading-6 focus-visible:ring-0 focus-visible:ring-offset-0 placeholder:text-muted-foreground/40 [scrollbar-width:thin] [scrollbar-color:hsl(var(--border))_transparent]"
         style={{ caretColor: BR_COLORS[caretIndex] }}
       />
     </div>


### PR DESCRIPTION
## O que foi feito?

* Adicionado feedback visual em tempo real sobre o status do salvamento automático na página `Editor`
* Criado o estado `SaveStatus`, com os seguintes status:
  * `idle`: nenhum salvamento em andamento
  * `saving`: nota sendo salva
  * `saved`: nota salva com sucesso
  * `error`: erro durante o salvamento
* Adicionado indicador no canto superior direito do editor, exibindo ícones e mensagens de acordo com o status atual
* Refatorada a lógica de auto-save para atualizar o `saveStatus` durante todo o fluxo de salvamento
* Ajustado o padding do componente `Textarea` para acomodar o novo indicador sem sobrepor o conteúdo

## Por que?

Para fornecer feedback claro ao usuário sobre o estado do auto-save.

Anteriormente, o salvamento acontecia sem indicação visual, dificultando saber se uma alteração estava sendo salva, se havia sido salva com sucesso ou se ocorreu algum erro.

Com essa alteração, o usuário consegue acompanhar o status do salvamento diretamente no editor, incluindo possíveis falhas de comunicação com o backend.

## Como testar?

1. Inicie a aplicação normalmente
2. Acesse uma nota na página `Editor`
3. Altere o conteúdo da nota e aguarde o auto-save
4. Verifique se o indicador apresenta o estado de salvamento e, após a conclusão, confirma que a nota foi salva
5. Atualize a página e confirme que as alterações foram persistidas
6. Para validar o cenário de erro, pare o backend:
```bash
   docker compose stop backend
```
7. Faça uma nova alteração na nota e aguarde o auto-save
8. Verifique se o indicador apresenta o estado de erro
9. Inicie novamente o backend:
```bash
   docker compose start backend
```

## Prints (se aplicável)

<img width="398" height="443" alt="Save status indicator" src="https://github.com/user-attachments/assets/ca1892c0-164e-472c-aa86-336b855c174d" />

<img width="401" height="425" alt="Saved status indicator" src="https://github.com/user-attachments/assets/6a46738c-a87e-437f-a958-5fa7dc7df086" />

<img width="401" height="419" alt="Error status indicator" src="https://github.com/user-attachments/assets/f533d244-ed48-4d36-89bd-c1e6b7f156bc" />

Closes #16

> [!NOTE]
> Foi identificado um erro de lint pré-existente no frontend, não relacionado às alterações deste PR:
>
> ```
> src/components/ui/button.tsx
> 50:18  error  Fast refresh only works when a file only exports components. Use a new file to share constants or functions between components  react-refresh/only-export-components
> ```
