### PR TITLE
[feat] Implementa cache local para contribuidores da API do GitHub

### DIFF
--- a/frontend/src/components/Contributors.tsx
+++ b/frontend/src/components/Contributors.tsx
@@ -7,16 +7,69 @@ interface Contributor {
   html_url: string
 }
 
+interface ContributorsCache {
+  contributors: Contributor[]
+  expiresAt: number
+}
+
+const CONTRIBUTORS_API_URL =
+  "https://api.github.com/repos/Navelogic/escreveaqui/contributors"
+const CONTRIBUTORS_CACHE_KEY = "escreveaqui:contributors"
+const CONTRIBUTORS_CACHE_TTL_MS = 60 * 60 * 1000
+
+function getCachedContributors(): Contributor[] | null {
+  try {
+    const cachedValue = localStorage.getItem(CONTRIBUTORS_CACHE_KEY)
+    if (!cachedValue) return null
+
+    const cache: ContributorsCache = JSON.parse(cachedValue)
+    if (cache.expiresAt <= Date.now() || !Array.isArray(cache.contributors)) {
+      localStorage.removeItem(CONTRIBUTORS_CACHE_KEY)
+      return null
+    }
+
+    return cache.contributors
+  } catch {
+    return null
+  }
+}
+
+function cacheContributors(contributors: Contributor[]) {
+  try {
+    const cache: ContributorsCache = {
+      contributors,
+      expiresAt: Date.now() + CONTRIBUTORS_CACHE_TTL_MS,
+    }
+
+    localStorage.setItem(CONTRIBUTORS_CACHE_KEY, JSON.stringify(cache))
+  } catch {
+    // A falha no cache não deve impedir a exibição dos contribuidores.
+  }
+}
+
 export default function Contributors() {
-  const [contributors, setContributors] = useState<Contributor[]>([])
+  const [contributors, setContributors] = useState<Contributor[]>(
+    () => getCachedContributors() ?? [],
+  )
 
   useEffect(() => {
-    fetch("https://api.github.com/repos/Navelogic/escreveaqui/contributors")
-      .then((res) => res.json())
-      .then((data) => {
-        if (Array.isArray(data)) setContributors(data)
+    if (getCachedContributors()) return
+
+    fetch(CONTRIBUTORS_API_URL)
+      .then((res) => {
+        if (!res.ok) throw new Error(`GitHub respondeu com status ${res.status}`)
+        return res.json()
       })
-      .catch((err) => console.error("Falha ao buscar contribuidores", err))
+      .then((data: unknown) => {
+        if (!Array.isArray(data)) return
+
+        const fetchedContributors = data as Contributor[]
+        cacheContributors(fetchedContributors)
+        setContributors(fetchedContributors)
+      })
+      .catch((err: unknown) =>
+        console.error("Falha ao buscar contribuidores", err),
+      )
   }, [])
 
   if (contributors.length === 0) return null


### PR DESCRIPTION
## O que foi feito?

* Adicionado cache client-side para a lista de contributors exibida pelo componente `Contributors`
* Criada a interface `ContributorsCache` para representar os dados armazenados em cache
* Adicionadas as funções auxiliares `getCachedContributors` e `cacheContributors` para leitura e gravação dos contributors no `localStorage`
* Configurado TTL de 1 hora para o cache, garantindo que dados expirados sejam descartados e buscados novamente pela API
* Ajustada a inicialização do componente para utilizar os contributors armazenados em cache, quando disponíveis
* Alterada a lógica de carregamento para evitar chamadas desnecessárias à API quando houver um cache válido
* Adicionado tratamento de erros nas operações de leitura e gravação do cache, evitando que problemas com o `localStorage` afetem o funcionamento da interface
* Melhorado o tratamento de falhas durante a busca dos contributors na API

## Por que?

Para reduzir chamadas desnecessárias à API e melhorar o desempenho do componente `Contributors`.

Anteriormente, a lista de contributors era buscada novamente sempre que o componente precisava carregar os dados, mesmo quando essas informações haviam sido obtidas recentemente.

Com essa alteração, os contributors ficam armazenados no `localStorage` por até 1 hora. Durante esse período, o componente reutiliza os dados disponíveis localmente e evita uma nova requisição à API.

Após a expiração do cache, uma nova requisição é realizada e os dados armazenados são atualizados, mantendo um equilíbrio entre performance e atualização das informações.

## Como testar?

1. Inicie a aplicação normalmente
2. Acesse a página ou seção que exibe o componente `Contributors`
3. Verifique no DevTools do navegador se a requisição para buscar os contributors é realizada normalmente
4. Confirme que os dados dos contributors são armazenados no `localStorage`
5. Atualize a página
6. Verifique se os contributors continuam sendo exibidos corretamente
7. Confirme no DevTools que uma nova requisição à API não é realizada enquanto o cache estiver válido
8. Remova manualmente o cache do `localStorage` e atualize a página
9. Confirme que uma nova requisição é realizada e que o cache é criado novamente
10. Para validar a expiração, altere ou simule um cache com mais de 1 hora e atualize a página
11. Confirme que o cache expirado é ignorado e que os contributors são buscados novamente pela API
12. Opcionalmente, valide um cenário em que o `localStorage` não esteja disponível ou uma operação de cache falhe e confirme que a interface continua funcionando sem quebrar

## Prints (se aplicável)

Quando não há cache salvo no localStorage:
<img width="1920" height="1032" alt="image" src="https://github.com/user-attachments/assets/bbd479df-6dc3-4e4e-985a-22186f6e0b89" />

Sistema realiza a busca via API (contributors):
<img width="1920" height="1032" alt="image" src="https://github.com/user-attachments/assets/b4f36a35-3d6a-4f5e-84fc-ba24d3e5c2b6" />

Salva os contributors em cache no localStorage:
<img width="1920" height="1032" alt="image" src="https://github.com/user-attachments/assets/f32ef88d-b9af-4493-b351-f9bd966994ae" />

Com o cache salvo no localStorage, o sistema não faz mais novas requisições à API:
<img width="1920" height="1032" alt="image" src="https://github.com/user-attachments/assets/81977507-6640-439f-aee4-4161aab5f513" />

Closes #12 