### PR TITLE
[enhance-home-avatars] -> [dev]: Melhoria de exibição e experiência para os Avatares da Tela de Entrada

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -8,6 +8,7 @@
       "name": "frontend",
       "version": "0.0.0",
       "dependencies": {
+        "@base-ui/react": "^1.7.0",
         "@radix-ui/react-dialog": "^1.1.15",
         "@radix-ui/react-slot": "^1.2.4",
         "@types/lodash.debounce": "^4.0.9",
@@ -288,6 +289,15 @@
         "@babel/core": "^7.0.0-0"
       }
     },
+    "node_modules/@babel/runtime": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.7.tgz",
+      "integrity": "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
     "node_modules/@babel/template": {
       "version": "7.28.6",
       "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.28.6.tgz",
@@ -334,6 +344,66 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@base-ui/react": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/@base-ui/react/-/react-1.7.0.tgz",
+      "integrity": "sha512-j+8QjX44C32jrXD/qyEAGpFr70FRpGL2CY61mQd9nBPWN737CK0xxD1ceJ055rW4RtdvFDT1e7otzdlfxvsYug==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.29.2",
+        "@base-ui/utils": "0.3.2",
+        "@floating-ui/react-dom": "^2.1.9",
+        "@floating-ui/utils": "^0.2.12",
+        "use-sync-external-store": "^1.6.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/mui-org"
+      },
+      "peerDependencies": {
+        "@date-fns/tz": "^1.2.0",
+        "@types/react": "^17 || ^18 || ^19",
+        "date-fns": "^4.0.0",
+        "react": "^17 || ^18 || ^19",
+        "react-dom": "^17 || ^18 || ^19"
+      },
+      "peerDependenciesMeta": {
+        "@date-fns/tz": {
+          "optional": true
+        },
+        "@types/react": {
+          "optional": true
+        },
+        "date-fns": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@base-ui/utils": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/@base-ui/utils/-/utils-0.3.2.tgz",
+      "integrity": "sha512-oWy1aq/I2GmYjpl4PhEAhzflF8VPGKgZeq0xAWTbfD5KBWyxcN0ZP2+WHSUm/5Z6lVMBDLReLcoXwSYoRc/zNQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.29.2",
+        "@floating-ui/utils": "^0.2.12",
+        "reselect": "^5.2.0",
+        "use-sync-external-store": "^1.6.0"
+      },
+      "peerDependencies": {
+        "@types/react": "^17 || ^18 || ^19",
+        "react": "^17 || ^18 || ^19",
+        "react-dom": "^17 || ^18 || ^19"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -934,6 +1004,44 @@
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
+    },
+    "node_modules/@floating-ui/core": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.8.0.tgz",
+      "integrity": "sha512-0CIZ5itps/8x7BG8dEIhs53BvCUH2PCoogtakwRTut+Arm58sJooJ0AuZhLw2HJYIR5cMLNPBSS728sPho2khQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/utils": "^0.2.12"
+      }
+    },
+    "node_modules/@floating-ui/dom": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.8.0.tgz",
+      "integrity": "sha512-yXSrzeHZBTZadLOlfyhCkJHNeLJnHRnRInwdZ40L7ZiaAtrBwoYlsDrX3v5zB1Utk7CLfzcOVnVVWoXEky7Ceg==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/core": "^1.8.0",
+        "@floating-ui/utils": "^0.2.12"
+      }
+    },
+    "node_modules/@floating-ui/react-dom": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-2.1.9.tgz",
+      "integrity": "sha512-JDjEFGCpImxDCA7JJKviA0M9+RtmJdj0m/NVU5IMgBK+AmZouAQQ7/+2GLH0GXXY0YMw9oXPB8hKdbPYg5QLYg==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/dom": "^1.8.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
+    "node_modules/@floating-ui/utils": {
+      "version": "0.2.12",
+      "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.12.tgz",
+      "integrity": "sha512-HpCo8tmWzLVad5s2d19EhAz5zqrrQ6s69qd6moPMQvkOuSwDT1YgRfWSVuc4ennqrgv3OHppiOGMQ7oC13yIww==",
+      "license": "MIT"
     },
     "node_modules/@humanfs/core": {
       "version": "0.19.2",
@@ -4428,6 +4536,12 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
+    "node_modules/reselect": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/reselect/-/reselect-5.3.0.tgz",
+      "integrity": "sha512-XGoLeRAVzUTcJ1qkxPQhDJyIZ5d6zzZD9nT7AEZOaaU9UbWclhycElmhO+VD5bFeLuzhPBaOV2oXC8uG35ZSpg==",
+      "license": "MIT"
+    },
     "node_modules/resolve": {
       "version": "1.22.12",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.12.tgz",
@@ -4940,6 +5054,15 @@
         "@types/react": {
           "optional": true
         }
+      }
+    },
+    "node_modules/use-sync-external-store": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
+      "integrity": "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/util-deprecate": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -10,6 +10,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "@base-ui/react": "^1.7.0",
     "@radix-ui/react-dialog": "^1.1.15",
     "@radix-ui/react-slot": "^1.2.4",
     "@types/lodash.debounce": "^4.0.9",

--- a/frontend/src/components/Contributors.tsx
+++ b/frontend/src/components/Contributors.tsx
@@ -1,4 +1,6 @@
 import { useEffect, useState } from "react"
+import { Tooltip, TooltipContent, TooltipTrigger } from "./ui/tooltip"
+import { Avatar, AvatarFallback, AvatarGroup, AvatarGroupCount, AvatarImage } from "./ui/avatar"
 
 interface Contributor {
   id: number
@@ -12,10 +14,17 @@ interface ContributorsCache {
   expiresAt: number
 }
 
-const CONTRIBUTORS_API_URL =
-  "https://api.github.com/repos/Navelogic/escreveaqui/contributors"
+interface ContributorsCountCache {
+  count: number | null 
+  expiresAt: number
+}
+
+const CONTRIBUTORS_GITHUB_GRAPH_URL = "https://github.com/Navelogic/escreveaqui/graphs/contributors"
+const CONTRIBUTORS_API_URL = "https://api.github.com/repos/Navelogic/escreveaqui/contributors"
 const CONTRIBUTORS_CACHE_KEY = "escreveaqui:contributors"
+const CONTRIBUTORS_COUNT_CACHE_KEY = "escreveaqui:contributors-count"
 const CONTRIBUTORS_CACHE_TTL_MS = 60 * 60 * 1000
+const CONTRIBUTORS_SLICE_COUNT = 8
 
 function getCachedContributors(): Contributor[] | null {
   try {
@@ -47,13 +56,74 @@ function cacheContributors(contributors: Contributor[]) {
   }
 }
 
+async function getContributorsCount() {
+  const res = await fetch(
+    `${CONTRIBUTORS_API_URL}?per_page=1&anon=true`,
+  )
+
+  if (!res.ok) throw new Error(`GitHub respondeu com status ${res.status}`)
+
+  const link = res.headers.get("Link")
+
+  if (!link) {
+    const data = await res.json()
+    return Array.isArray(data) ? data.length : 0
+  }
+
+  const lastPageLink = link
+    .split(",")
+    .find((part) => part.includes('rel="last"'))
+
+  const lastPageUrl = lastPageLink?.match(/<([^>]+)>/)?.[1]
+  const lastPage = lastPageUrl
+    ? new URL(lastPageUrl).searchParams.get("page")
+    : null
+
+  return lastPage ? Number(lastPage) : 0
+}
+
+
+function getCachedContributorsCount(): number | null {
+  try {
+    const cachedValue = localStorage.getItem(CONTRIBUTORS_COUNT_CACHE_KEY)
+    if (!cachedValue) return null
+
+    const cache: ContributorsCountCache = JSON.parse(cachedValue)
+    if (cache.expiresAt <= Date.now() || !Number.isInteger(cache.count)) {
+      localStorage.removeItem(CONTRIBUTORS_COUNT_CACHE_KEY)
+      return null
+    }
+
+    return cache.count
+  } catch {
+    return null
+  }
+}
+
+function cacheContributorsCount(count: number | null) {
+  try {
+    const cache: ContributorsCountCache = {
+      count,
+      expiresAt: Date.now() + CONTRIBUTORS_CACHE_TTL_MS,
+    }
+
+    localStorage.setItem(CONTRIBUTORS_COUNT_CACHE_KEY, JSON.stringify(cache))
+  } catch {
+    // A falha no cache não deve impedir a exibição do número de contribuidores.
+  }
+}
+
+
 export default function Contributors() {
   const [contributors, setContributors] = useState<Contributor[]>(
     () => getCachedContributors() ?? [],
   )
+  const [contributorsCount, setContributorsCount] = useState<number | null>(
+    () => getCachedContributorsCount()
+  )
 
   useEffect(() => {
-    if (getCachedContributors()) return
+    if (getCachedContributors() && getCachedContributorsCount()) return
 
     fetch(CONTRIBUTORS_API_URL)
       .then((res) => {
@@ -70,6 +140,18 @@ export default function Contributors() {
       .catch((err: unknown) =>
         console.error("Falha ao buscar contribuidores", err),
       )
+
+    getContributorsCount()
+      .then((data: unknown) => {
+        if (!Number.isInteger(data)) return
+
+        const fetchedCount = data as number
+        const slicedCount = Math.max(0, fetchedCount - CONTRIBUTORS_SLICE_COUNT)
+        cacheContributorsCount(slicedCount)
+        setContributorsCount(slicedCount)
+      })
+      .catch((err: unknown) => console.error("Falha ao buscar número de contribuidores", err))
+
   }, [])
 
   if (contributors.length === 0) return null
@@ -77,22 +159,53 @@ export default function Contributors() {
   return (
     <div className="flex flex-wrap items-center gap-2">
       <span className="text-xs text-muted-foreground">Contribuidores</span>
-      {contributors.map((contributor) => (
-        <a
-          key={contributor.id}
-          href={contributor.html_url}
-          target="_blank"
-          rel="noopener noreferrer"
-          title={contributor.login}
-          className="transition-transform hover:scale-110"
-        >
-          <img
-            src={contributor.avatar_url}
-            alt={contributor.login}
-            className="w-8 h-8 rounded-full"
-          />
-        </a>
-      ))}
+      <AvatarGroup>
+        {contributors.slice(0, CONTRIBUTORS_SLICE_COUNT).map((contributor) => (
+          <Tooltip key={contributor.id}>
+            <TooltipTrigger
+              render={
+                <a
+                  href={contributor.html_url}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  aria-label={`Abrir perfil de ${contributor.login} no GitHub`}
+                  className="relative transition-transform hover:z-10 hover:scale-110 focus-visible:z-10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+                />
+              }
+            >
+              <Avatar>
+                <AvatarImage src={contributor.avatar_url} alt={contributor.login} />
+                <AvatarFallback>
+                  {contributor.login.slice(0, 2).toUpperCase()}
+                </AvatarFallback>
+              </Avatar>
+            </TooltipTrigger>
+            <TooltipContent>{contributor.login}</TooltipContent>
+          </Tooltip>
+        ))}
+        {contributorsCount !== 0 ? (
+          <Tooltip>
+            <TooltipTrigger
+              render={
+                <a
+                  href={CONTRIBUTORS_GITHUB_GRAPH_URL}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  aria-label="Abrir painel de contribuidores no GitHub"
+                  className="relative transition-transform hover:z-10 hover:scale-110 focus-visible:z-10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+                />
+              }
+            >
+              <AvatarGroupCount>
+                +{contributorsCount}
+              </AvatarGroupCount>
+            </TooltipTrigger>
+            <TooltipContent>
+              ver mais contribuidores
+            </TooltipContent>
+          </Tooltip>
+        ): null}
+      </AvatarGroup>
     </div>
   )
 }

--- a/frontend/src/components/ui/avatar.tsx
+++ b/frontend/src/components/ui/avatar.tsx
@@ -1,0 +1,107 @@
+import * as React from "react"
+import { Avatar as AvatarPrimitive } from "@base-ui/react/avatar"
+
+import { cn } from "@/lib/utils"
+
+function Avatar({
+  className,
+  size = "default",
+  ...props
+}: AvatarPrimitive.Root.Props & {
+  size?: "default" | "sm" | "lg"
+}) {
+  return (
+    <AvatarPrimitive.Root
+      data-slot="avatar"
+      data-size={size}
+      className={cn(
+        "group/avatar relative flex size-8 shrink-0 rounded-full select-none after:absolute after:inset-0 after:rounded-full after:border after:border-border after:mix-blend-darken data-[size=lg]:size-10 data-[size=sm]:size-6 dark:after:mix-blend-lighten",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function AvatarImage({ className, ...props }: AvatarPrimitive.Image.Props) {
+  return (
+    <AvatarPrimitive.Image
+      data-slot="avatar-image"
+      className={cn(
+        "aspect-square size-full rounded-full object-cover",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function AvatarFallback({
+  className,
+  ...props
+}: AvatarPrimitive.Fallback.Props) {
+  return (
+    <AvatarPrimitive.Fallback
+      data-slot="avatar-fallback"
+      className={cn(
+        "flex size-full items-center justify-center rounded-full bg-muted text-sm text-muted-foreground group-data-[size=sm]/avatar:text-xs",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function AvatarBadge({ className, ...props }: React.ComponentProps<"span">) {
+  return (
+    <span
+      data-slot="avatar-badge"
+      className={cn(
+        "absolute right-0 bottom-0 z-10 inline-flex items-center justify-center rounded-full bg-primary text-primary-foreground bg-blend-color ring-2 ring-background select-none",
+        "group-data-[size=sm]/avatar:size-2 group-data-[size=sm]/avatar:[&>svg]:hidden",
+        "group-data-[size=default]/avatar:size-2.5 group-data-[size=default]/avatar:[&>svg]:size-2",
+        "group-data-[size=lg]/avatar:size-3 group-data-[size=lg]/avatar:[&>svg]:size-2",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function AvatarGroup({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="avatar-group"
+      className={cn(
+        "group/avatar-group flex -space-x-2 *:data-[slot=avatar]:ring-2 *:data-[slot=avatar]:ring-background",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function AvatarGroupCount({
+  className,
+  ...props
+}: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="avatar-group-count"
+      className={cn(
+        "relative flex size-8 shrink-0 items-center justify-center rounded-full bg-muted text-sm text-muted-foreground ring-2 ring-background group-has-data-[size=lg]/avatar-group:size-10 group-has-data-[size=sm]/avatar-group:size-6 [&>svg]:size-4 group-has-data-[size=lg]/avatar-group:[&>svg]:size-5 group-has-data-[size=sm]/avatar-group:[&>svg]:size-3",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+export {
+  Avatar,
+  AvatarImage,
+  AvatarFallback,
+  AvatarGroup,
+  AvatarGroupCount,
+  AvatarBadge,
+}

--- a/frontend/src/components/ui/tooltip.tsx
+++ b/frontend/src/components/ui/tooltip.tsx
@@ -1,0 +1,64 @@
+import { Tooltip as TooltipPrimitive } from "@base-ui/react/tooltip"
+
+import { cn } from "@/lib/utils"
+
+function TooltipProvider({
+  delay = 0,
+  ...props
+}: TooltipPrimitive.Provider.Props) {
+  return (
+    <TooltipPrimitive.Provider
+      data-slot="tooltip-provider"
+      delay={delay}
+      {...props}
+    />
+  )
+}
+
+function Tooltip({ ...props }: TooltipPrimitive.Root.Props) {
+  return <TooltipPrimitive.Root data-slot="tooltip" {...props} />
+}
+
+function TooltipTrigger({ ...props }: TooltipPrimitive.Trigger.Props) {
+  return <TooltipPrimitive.Trigger data-slot="tooltip-trigger" {...props} />
+}
+
+function TooltipContent({
+  className,
+  side = "top",
+  sideOffset = 4,
+  align = "center",
+  alignOffset = 0,
+  children,
+  ...props
+}: TooltipPrimitive.Popup.Props &
+  Pick<
+    TooltipPrimitive.Positioner.Props,
+    "align" | "alignOffset" | "side" | "sideOffset"
+  >) {
+  return (
+    <TooltipPrimitive.Portal>
+      <TooltipPrimitive.Positioner
+        align={align}
+        alignOffset={alignOffset}
+        side={side}
+        sideOffset={sideOffset}
+        className="isolate z-50"
+      >
+        <TooltipPrimitive.Popup
+          data-slot="tooltip-content"
+          className={cn(
+            "z-50 inline-flex w-fit max-w-xs origin-(--transform-origin) items-center gap-1.5 rounded-md bg-foreground px-3 py-1.5 text-xs text-background has-data-[slot=kbd]:pr-1.5 data-[side=bottom]:slide-in-from-top-2 data-[side=inline-end]:slide-in-from-left-2 data-[side=inline-start]:slide-in-from-right-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 **:data-[slot=kbd]:relative **:data-[slot=kbd]:isolate **:data-[slot=kbd]:z-50 **:data-[slot=kbd]:rounded-sm data-[state=delayed-open]:animate-in data-[state=delayed-open]:fade-in-0 data-[state=delayed-open]:zoom-in-95 data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95",
+            className
+          )}
+          {...props}
+        >
+          {children}
+          <TooltipPrimitive.Arrow className="z-50 size-2.5 translate-y-[calc(-50%-2px)] rotate-45 rounded-[2px] bg-foreground fill-foreground data-[side=bottom]:top-1 data-[side=inline-end]:top-1/2! data-[side=inline-end]:-left-1 data-[side=inline-end]:-translate-y-1/2 data-[side=inline-start]:top-1/2! data-[side=inline-start]:-right-1 data-[side=inline-start]:-translate-y-1/2 data-[side=left]:top-1/2! data-[side=left]:-right-1 data-[side=left]:-translate-y-1/2 data-[side=right]:top-1/2! data-[side=right]:-left-1 data-[side=right]:-translate-y-1/2 data-[side=top]:-bottom-2.5" />
+        </TooltipPrimitive.Popup>
+      </TooltipPrimitive.Positioner>
+    </TooltipPrimitive.Portal>
+  )
+}
+
+export { Tooltip, TooltipTrigger, TooltipContent, TooltipProvider }


### PR DESCRIPTION
## O que foi feito?

Foram acrescentandos componentes avatar e tooltip da biblioteca em uso (shadcn-ui/ui) e refatorado o componente “Contributors” para o uso destes componentes, obtendo uma apresentação visual mais agradável e flexível conforme o número de contribuidores aumentar. 

Nesta implementação, será observado:

- Ao realizar hover sobre os avatares, haverá uma leve animação que coloca em destaque o perfil;
- No momento do hover, o tooltip evidencia o username do GitHub;
- O tooltip renderiza o avatar como um elemento âncora, redirecionando o clique no avatar diretamente para a conta do usuário;
- O elemento avatar, ao atingir o número máximo manipulável de perfis visíveis, irá acrescentar após o último avatar um contador com quantos usuários a mais existem contribuindo com o repositório (lembrando que neste contador, também serão contados perfis privados);
- Ao realizar hover sobre o contador de contribuidores adicionais, irá aparecer um tooltip sinalizando o caminho de abertura do gráfico de contribuição do repositório, ao clicar, será direcionado para o mesmo.

Diante do exposto, essa alteração está restrita apenas a:

- Contributors.tsx → Mudanças citadas
- package.json → Acréscimo da biblioteca originária dos componentes shadcn usados
- package-lock.json → Acréscimo da biblioteca originária dos componentes shadcn usados

Igualmente, as adições estão restritas apenas a:

- src/components/ui
    - avatar.tsx
    - tooltip.tsx

## Por que?

Estas alterações e adições são baseadas em testes no front-end visando entender o comportamento do componente “Contributors” com o acréscimo de mais contribuidores ao repositório. Nestes testes, foi observada a quebra de linhas e não exibição completa dos contribuidores perante requisição à API do GitHub.

Corroborando com o fator exposto, o uso de um componente já existente pela biblioteca visual adotada poderia aumentar a praticidade de manutenção à longo prazo, considerando maior flexibilidade e solução já pronta.

## Como testar?

Apenas altere (localmente) a constante “CONTRIBUTORS_API_URL” para algum repositório com ≥ 9 contribuidores (considerando até o presente momento deste PR o repositório não possuir este número de contribuições) e, também, altere o caminho das KEYs de cache. Após isso, verá o componente funcionando em sua totalidade conforme os parâmetros indicados na explicação.

## Prints (se aplicável)

Atual, em produção:

<img width="960" height="956" alt="image" src="https://github.com/user-attachments/assets/e31f5281-67bb-4b55-8570-cb2b9d9c1cf5" />

Atual, em local, redirecionando para o URL do Shadcn UI: 

<img width="959" height="956" alt="image" src="https://github.com/user-attachments/assets/46753d8d-5074-4ad8-9b84-a389bf4585dc" />

Esta PR, em local, com as alterações mencionadas:

<img width="957" height="956" alt="image" src="https://github.com/user-attachments/assets/175d0e06-230a-4767-9861-0ce03da4b7e0" />


Esta PR, em local, com as alterações mencionadas e redirecionado para a URL do Shadcn UI:

<img width="959" height="957" alt="image" src="https://github.com/user-attachments/assets/2aedd102-6fab-4406-ae89-3bdd73f89579" />
