### PR TITLE
feat: adiciona link para voltar à home a partir do editor

### DIFF
--- a/frontend/src/pages/Editor/index.tsx
+++ b/frontend/src/pages/Editor/index.tsx
@@ -1,4 +1,4 @@
-import { useParams } from "react-router-dom"
+import { useParams, Link } from "react-router-dom"
 import { useState, useEffect, useRef, useMemo } from "react"
 import { Textarea } from "@/components/ui/textarea"
 import { notaService } from "@/services/notaService"
@@ -118,6 +118,12 @@ export default function Editor() {
 
   return (
     <div className="w-full h-screen bg-background">
+      <Link
+        to="/"
+        className="fixed left-5 top-4 z-10 font-mono text-sm text-foreground/55 hover:text-foreground transition-colors"
+      >
+        escreveaqui.com.br
+      </Link>
       {saveStatus !== "idle" && (
         <div
           aria-live="polite"


### PR DESCRIPTION
# O que foi feito?

Adicionado link escreveaqui.com.br no canto superior esquerdo da página do Editor, permitindo que o usuário volte para a Home com um clique.

## Por que?

Atualmente não era possível voltar para a Home a partir de uma nota sem usar o botão voltar do navegador ou manipular a URL manualmente (issue #29).

## Como testar?

1. Acesse qualquer nota (ex: )
2. Clique em escreveaqui.com.br no canto superior esquerdo
3. Verifique se navega de volta para a Home

## Mudanças

- `src/pages/Editor/index.tsx`: adicionado `<Link to=/>` do react-router-dom com posicionamento fixo no topo-esquerdo, espelhando o indicador de salvamento no topo-direito.

Closes #29

## Preview

<img width="1280" height="577" alt="editor-back-link" src="https://github.com/user-attachments/assets/6cce6ef3-2611-4096-8b9c-29a00b49f6bf" />
