### PR TITLE
feat: substitui HTTP Polling por Server-Sent Events (SSE) em tempo real

### DIFF
--- a/backend/src/main/java/br/com/escreveaqui/backend/controllers/NotaController.java
+++ b/backend/src/main/java/br/com/escreveaqui/backend/controllers/NotaController.java
@@ -5,6 +5,7 @@ import br.com.escreveaqui.backend.dtos.NotaResponseDTO;
 import br.com.escreveaqui.backend.services.ReadNotaService;
 import br.com.escreveaqui.backend.services.SseService;
 import br.com.escreveaqui.backend.services.UpsertNotaService;
+import br.com.escreveaqui.backend.utils.SlugUtils;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
@@ -27,11 +28,9 @@ public class NotaController {
     private final UpsertNotaService upsertService;
     private final SseService sseService;
 
-    private static final String SLUG_REGEX = "^[A-Za-z0-9_\\s-]+$";
-
     @GetMapping(value = "/{slug}", produces = "application/json")
     public ResponseEntity<NotaResponseDTO> read(
-            @PathVariable @Pattern(regexp = SLUG_REGEX) String slug,
+            @PathVariable @Pattern(regexp = SlugUtils.SLUG_REGEX) String slug,
             HttpServletRequest request,
             HttpServletResponse response
     ) {
@@ -48,7 +47,7 @@ public class NotaController {
 
     @GetMapping(value = "/{slug}/stream", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
     public SseEmitter stream(
-            @PathVariable @Pattern(regexp = SLUG_REGEX) String slug
+            @PathVariable @Pattern(regexp = SlugUtils.SLUG_REGEX) String slug
     ) {
         return sseService.subscribe(slug);
     }
@@ -56,7 +55,7 @@ public class NotaController {
     @PutMapping(value = "/{slug}", consumes = "application/json")
     public ResponseEntity<Void> upsert(
             @PathVariable
-            @Pattern(regexp = SLUG_REGEX) String slug,
+            @Pattern(regexp = SlugUtils.SLUG_REGEX) String slug,
             @RequestBody
             @Valid NotaRequestDTO request
     ) {

--- a/backend/src/main/java/br/com/escreveaqui/backend/controllers/NotaController.java
+++ b/backend/src/main/java/br/com/escreveaqui/backend/controllers/NotaController.java
@@ -3,6 +3,7 @@ package br.com.escreveaqui.backend.controllers;
 import br.com.escreveaqui.backend.dtos.NotaRequestDTO;
 import br.com.escreveaqui.backend.dtos.NotaResponseDTO;
 import br.com.escreveaqui.backend.services.ReadNotaService;
+import br.com.escreveaqui.backend.services.SseService;
 import br.com.escreveaqui.backend.services.UpsertNotaService;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
@@ -10,9 +11,11 @@ import jakarta.validation.Valid;
 import jakarta.validation.constraints.Pattern;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
 @RestController
 @RequestMapping("/api/v1/notes")
@@ -22,6 +25,7 @@ public class NotaController {
 
     private final ReadNotaService readService;
     private final UpsertNotaService upsertService;
+    private final SseService sseService;
 
     private static final String SLUG_REGEX = "^[A-Za-z0-9_\\s-]+$";
 
@@ -40,6 +44,13 @@ public class NotaController {
             return ResponseEntity.status(HttpStatus.NOT_MODIFIED).build();
         }
         return ResponseEntity.ok().body(nota);
+    }
+
+    @GetMapping(value = "/{slug}/stream", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
+    public SseEmitter stream(
+            @PathVariable @Pattern(regexp = SLUG_REGEX) String slug
+    ) {
+        return sseService.subscribe(slug);
     }
 
     @PutMapping(value = "/{slug}", consumes = "application/json")

--- a/backend/src/main/java/br/com/escreveaqui/backend/services/SseService.java
+++ b/backend/src/main/java/br/com/escreveaqui/backend/services/SseService.java
@@ -10,18 +10,33 @@ import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CopyOnWriteArrayList;
 
+/**
+ * Serviço responsável por gerenciar transmissões em tempo real via Server-Sent Events (SSE).
+ * Mantém conexões ativas agrupadas por slug de nota e dispara atualizações para os clientes.
+ */
 @Slf4j
 @Service
 public class SseService {
 
+    /**
+     * Mapa thread-safe contendo a lista de transmissores SSE ativos associados a cada slug.
+     */
     private final Map<String, List<SseEmitter>> emitters = new ConcurrentHashMap<>();
 
+    /**
+     * Inscreve um novo cliente para ouvir atualizações em tempo real de uma nota específica.
+     *
+     * @param rawSlug O slug da nota desejada.
+     * @return O objeto {@link SseEmitter} para a conexão HTTP streaming.
+     */
     public SseEmitter subscribe(String rawSlug) {
         String slug = SlugUtils.format(rawSlug);
+        // Timeout 0L indica conexão aberta sem expiração prematura pelo servidor
         SseEmitter emitter = new SseEmitter(0L);
 
         emitters.computeIfAbsent(slug, k -> new CopyOnWriteArrayList<>()).add(emitter);
 
+        // Callbacks de limpeza para evitar vazamento de memória (memory leak)
         emitter.onCompletion(() -> removeEmitter(slug, emitter));
         emitter.onTimeout(() -> removeEmitter(slug, emitter));
         emitter.onError((e) -> removeEmitter(slug, emitter));
@@ -30,6 +45,12 @@ public class SseService {
         return emitter;
     }
 
+    /**
+     * Transmite o novo conteúdo de uma nota para todos os clientes ativos inscritos naquele slug.
+     *
+     * @param rawSlug O slug da nota atualizada.
+     * @param content O novo conteúdo da nota.
+     */
     public void notify(String rawSlug, String content) {
         String slug = SlugUtils.format(rawSlug);
         List<SseEmitter> list = emitters.get(slug);
@@ -44,11 +65,15 @@ public class SseService {
                         .name("nota-update")
                         .data(content));
             } catch (Exception e) {
+                // Em caso de falha de envio (cliente desconectado), remove o transmissor da lista
                 removeEmitter(slug, emitter);
             }
         }
     }
 
+    /**
+     * Remove um transmissor inativo da lista de inscritos do slug e limpa o mapa se a lista ficar vazia.
+     */
     private void removeEmitter(String slug, SseEmitter emitter) {
         List<SseEmitter> list = emitters.get(slug);
         if (list != null) {

--- a/backend/src/main/java/br/com/escreveaqui/backend/services/SseService.java
+++ b/backend/src/main/java/br/com/escreveaqui/backend/services/SseService.java
@@ -1,0 +1,62 @@
+package br.com.escreveaqui.backend.services;
+
+import br.com.escreveaqui.backend.utils.SlugUtils;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CopyOnWriteArrayList;
+
+@Slf4j
+@Service
+public class SseService {
+
+    private final Map<String, List<SseEmitter>> emitters = new ConcurrentHashMap<>();
+
+    public SseEmitter subscribe(String rawSlug) {
+        String slug = SlugUtils.format(rawSlug);
+        SseEmitter emitter = new SseEmitter(0L);
+
+        emitters.computeIfAbsent(slug, k -> new CopyOnWriteArrayList<>()).add(emitter);
+
+        emitter.onCompletion(() -> removeEmitter(slug, emitter));
+        emitter.onTimeout(() -> removeEmitter(slug, emitter));
+        emitter.onError((e) -> removeEmitter(slug, emitter));
+
+        log.debug("Novo inscrito SSE para o slug='{}'", slug);
+        return emitter;
+    }
+
+    public void notify(String rawSlug, String content) {
+        String slug = SlugUtils.format(rawSlug);
+        List<SseEmitter> list = emitters.get(slug);
+        if (list == null || list.isEmpty()) {
+            return;
+        }
+
+        log.debug("Notificando {} inscrito(s) SSE para o slug='{}'", list.size(), slug);
+        for (SseEmitter emitter : list) {
+            try {
+                emitter.send(SseEmitter.event()
+                        .name("nota-update")
+                        .data(content));
+            } catch (Exception e) {
+                removeEmitter(slug, emitter);
+            }
+        }
+    }
+
+    private void removeEmitter(String slug, SseEmitter emitter) {
+        List<SseEmitter> list = emitters.get(slug);
+        if (list != null) {
+            list.remove(emitter);
+            if (list.isEmpty()) {
+                emitters.remove(slug);
+            }
+        }
+        log.debug("Inscrito SSE removido para o slug='{}'", slug);
+    }
+}

--- a/backend/src/main/java/br/com/escreveaqui/backend/services/UpsertNotaService.java
+++ b/backend/src/main/java/br/com/escreveaqui/backend/services/UpsertNotaService.java
@@ -13,11 +13,13 @@ import org.springframework.stereotype.Service;
 public class UpsertNotaService {
 
     private final NotaRepository notaRepository;
+    private final SseService sseService;
     private final Counter createCounter;
     private final Counter updateCounter;
 
-    public UpsertNotaService(NotaRepository notaRepository, MeterRegistry registry) {
+    public UpsertNotaService(NotaRepository notaRepository, SseService sseService, MeterRegistry registry) {
         this.notaRepository = notaRepository;
+        this.sseService = sseService;
         this.createCounter = Counter.builder("notes.upsert")
                 .tag("operation", "create")
                 .description("Notas criadas")
@@ -33,6 +35,7 @@ public class UpsertNotaService {
         String safeSlug = SlugUtils.format(slug);
 
         boolean isNew = notaRepository.upsert(safeSlug, content);
+        sseService.notify(safeSlug, content);
 
         if (isNew) createCounter.increment();
         else updateCounter.increment();

--- a/backend/src/main/java/br/com/escreveaqui/backend/utils/SlugUtils.java
+++ b/backend/src/main/java/br/com/escreveaqui/backend/utils/SlugUtils.java
@@ -5,6 +5,8 @@ import java.util.regex.Pattern;
 
 public final class SlugUtils {
 
+    public static final String SLUG_REGEX = "^[A-Za-z0-9_\\s-]+$";
+
     private static final Pattern ACCENT_PATTERN = Pattern.compile("\\p{InCombiningDiacriticalMarks}+");
 
     private SlugUtils() {

--- a/backend/src/test/java/br/com/escreveaqui/backend/controllers/NotaControllerSseTest.java
+++ b/backend/src/test/java/br/com/escreveaqui/backend/controllers/NotaControllerSseTest.java
@@ -1,0 +1,60 @@
+package br.com.escreveaqui.backend.controllers;
+
+import br.com.escreveaqui.backend.services.ReadNotaService;
+import br.com.escreveaqui.backend.services.SseService;
+import br.com.escreveaqui.backend.services.UpsertNotaService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.request;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@ExtendWith(MockitoExtension.class)
+class NotaControllerSseTest {
+
+    private MockMvc mockMvc;
+
+    @Mock
+    private ReadNotaService readService;
+
+    @Mock
+    private UpsertNotaService upsertService;
+
+    @Mock
+    private SseService sseService;
+
+    @InjectMocks
+    private NotaController notaController;
+
+    @BeforeEach
+    void setUp() {
+        mockMvc = MockMvcBuilders.standaloneSetup(notaController).build();
+    }
+
+    @Test
+    @DisplayName("GET /api/v1/notes/{slug}/stream deve iniciar transmissão SSE assíncrona")
+    void deveIniciarTransmissaoSse() throws Exception {
+        String slug = "minha-nota";
+        SseEmitter emitter = new SseEmitter(0L);
+
+        when(sseService.subscribe(slug)).thenReturn(emitter);
+
+        mockMvc.perform(get("/api/v1/notes/{slug}/stream", slug)
+                        .accept(MediaType.TEXT_EVENT_STREAM_VALUE))
+                .andExpect(request().asyncStarted());
+
+        verify(sseService).subscribe(slug);
+    }
+}

--- a/backend/src/test/java/br/com/escreveaqui/backend/services/SseServiceTest.java
+++ b/backend/src/test/java/br/com/escreveaqui/backend/services/SseServiceTest.java
@@ -1,0 +1,45 @@
+package br.com.escreveaqui.backend.services;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+
+class SseServiceTest {
+
+    private SseService sseService;
+
+    @BeforeEach
+    void setUp() {
+        sseService = new SseService();
+    }
+
+    @Test
+    @DisplayName("Deve criar e retornar um SseEmitter para o slug informado")
+    void deveInscreverSlugComSucesso() {
+        String rawSlug = "Minha Nota SSE!";
+        SseEmitter emitter = sseService.subscribe(rawSlug);
+
+        assertThat(emitter).isNotNull();
+    }
+
+    @Test
+    @DisplayName("Deve notificar sem exceção quando não houver inscritos")
+    void deveNotificarSemInscritosSemLancarExcecao() {
+        assertThatCode(() -> sseService.notify("slug-sem-inscritos", "Novo Conteudo"))
+                .doesNotThrowAnyException();
+    }
+
+    @Test
+    @DisplayName("Deve notificar inscritos sanitizando o slug")
+    void deveNotificarInscritosSanitizandoSlug() {
+        String rawSlug = "Nota Compartilhada";
+        SseEmitter emitter = sseService.subscribe(rawSlug);
+
+        assertThatCode(() -> sseService.notify("nota-compartilhada", "Conteudo Atualizado"))
+                .doesNotThrowAnyException();
+    }
+}

--- a/backend/src/test/java/br/com/escreveaqui/backend/services/UpsertNotaServiceSseTest.java
+++ b/backend/src/test/java/br/com/escreveaqui/backend/services/UpsertNotaServiceSseTest.java
@@ -1,0 +1,48 @@
+package br.com.escreveaqui.backend.services;
+
+import br.com.escreveaqui.backend.repositories.NotaRepository;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class UpsertNotaServiceSseTest {
+
+    @Mock
+    private NotaRepository notaRepository;
+
+    @Mock
+    private SseService sseService;
+
+    private MeterRegistry meterRegistry;
+    private UpsertNotaService upsertNotaService;
+
+    @BeforeEach
+    void setUp() {
+        meterRegistry = new SimpleMeterRegistry();
+        upsertNotaService = new UpsertNotaService(notaRepository, sseService, meterRegistry);
+    }
+
+    @Test
+    @DisplayName("Deve notificar inscritos SSE ao criar ou atualizar uma nota")
+    void deveNotificarInscritosSseAoSalvar() {
+        String rawSlug = "Nota em Tempo Real";
+        String sanitizedSlug = "nota-em-tempo-real";
+        String content = "Conteudo transmitido via SSE";
+
+        when(notaRepository.upsert(sanitizedSlug, content)).thenReturn(true);
+
+        upsertNotaService.execute(rawSlug, content);
+
+        verify(notaRepository).upsert(sanitizedSlug, content);
+        verify(sseService).notify(sanitizedSlug, content);
+    }
+}

--- a/backend/src/test/java/br/com/escreveaqui/backend/services/UpsertNotaServiceTest.java
+++ b/backend/src/test/java/br/com/escreveaqui/backend/services/UpsertNotaServiceTest.java
@@ -19,13 +19,16 @@ class UpsertNotaServiceTest {
     @Mock
     private NotaRepository notaRepository;
 
+    @Mock
+    private SseService sseService;
+
     private MeterRegistry meterRegistry;
     private UpsertNotaService upsertNotaService;
 
     @BeforeEach
     void setUp() {
         meterRegistry = new SimpleMeterRegistry();
-        upsertNotaService = new UpsertNotaService(notaRepository, meterRegistry);
+        upsertNotaService = new UpsertNotaService(notaRepository, sseService, meterRegistry);
     }
 
     @Test

--- a/frontend/src/pages/Editor/index.tsx
+++ b/frontend/src/pages/Editor/index.tsx
@@ -41,12 +41,16 @@ export default function Editor() {
     return () => clearInterval(interval)
   }, [])
 
+  const isTypingRef = useRef(isTyping)
+  useEffect(() => {
+    isTypingRef.current = isTyping
+  }, [isTyping])
+
+  // 1. Busca inicial da nota (executa apenas uma vez ao montar ou mudar de slug)
   useEffect(() => {
     if (!key) return
-
     let isMounted = true
 
-    // Busca inicial do conteúdo da nota
     notaService.getBySlug(key)
       .then((nota) => {
         if (isMounted && nota?.content !== undefined) {
@@ -57,14 +61,22 @@ export default function Editor() {
         console.error("Erro na busca inicial da nota:", err)
       })
 
-    // Conexão SSE para atualizações em tempo real
+    return () => {
+      isMounted = false
+    }
+  }, [key])
+
+  // 2. Conexão SSE para atualizações remotas em tempo real (não resseta ao digitar)
+  useEffect(() => {
+    if (!key) return
+
     const baseUrl = import.meta.env.VITE_API_BASE_URL ?? "http://localhost:8080/api/v1/notes"
     const sseUrl = `${baseUrl}/${encodeURIComponent(key)}/stream`
     const eventSource = new EventSource(sseUrl)
 
     eventSource.addEventListener("nota-update", (event: MessageEvent) => {
       const newContent = event.data
-      if (isMounted && !isTyping && newContent !== text) {
+      if (!isTypingRef.current) {
         setText(newContent)
       }
     })
@@ -74,10 +86,9 @@ export default function Editor() {
     }
 
     return () => {
-      isMounted = false
       eventSource.close()
     }
-  }, [key, isTyping, text])
+  }, [key])
 
   const saveToBackend: DebouncedFunc<(slug: string, content: string) => void> = useMemo(
     () =>

--- a/frontend/src/pages/Editor/index.tsx
+++ b/frontend/src/pages/Editor/index.tsx
@@ -4,7 +4,6 @@ import { Textarea } from "@/components/ui/textarea"
 import { notaService } from "@/services/notaService"
 import { formatSlug } from "@/lib/utils"
 import debounce from "lodash.debounce"
-import axios from "axios"
 import type { DebouncedFunc } from "lodash"
 import { Check, LoaderCircle, X } from "lucide-react"
 
@@ -45,36 +44,38 @@ export default function Editor() {
   useEffect(() => {
     if (!key) return
 
-    let controller: AbortController | null = null
+    let isMounted = true
 
-    const fetchUpdates = async () => {
-      if (isTyping || document.hidden) return
-      controller?.abort()
-      controller = new AbortController()
-      try {
-        const nota = await notaService.getBySlug(key, controller.signal)
-        if (nota?.content !== undefined && nota.content !== text) {
+    // Busca inicial do conteúdo da nota
+    notaService.getBySlug(key)
+      .then((nota) => {
+        if (isMounted && nota?.content !== undefined) {
           setText(nota.content)
         }
-      } catch (err) {
-        if (!axios.isCancel(err)) {
-          console.error("Erro no polling de atualização:", err)
-        }
+      })
+      .catch((err) => {
+        console.error("Erro na busca inicial da nota:", err)
+      })
+
+    // Conexão SSE para atualizações em tempo real
+    const baseUrl = import.meta.env.VITE_API_BASE_URL ?? "http://localhost:8080/api/v1/notes"
+    const sseUrl = `${baseUrl}/${encodeURIComponent(key)}/stream`
+    const eventSource = new EventSource(sseUrl)
+
+    eventSource.addEventListener("nota-update", (event: MessageEvent) => {
+      const newContent = event.data
+      if (isMounted && !isTyping && newContent !== text) {
+        setText(newContent)
       }
-    }
+    })
 
-    const handleVisibilityChange = () => {
-      if (!document.hidden) fetchUpdates()
+    eventSource.onerror = (err) => {
+      console.debug("Conexão SSE reconectando...", err)
     }
-
-    fetchUpdates()
-    document.addEventListener("visibilitychange", handleVisibilityChange)
-    const interval = setInterval(fetchUpdates, 2000)
 
     return () => {
-      controller?.abort()
-      clearInterval(interval)
-      document.removeEventListener("visibilitychange", handleVisibilityChange)
+      isMounted = false
+      eventSource.close()
     }
   }, [key, isTyping, text])
 


### PR DESCRIPTION
## O que foi feito?

### 🛠️ Backend (Spring Boot)
- **Serviço de Streaming (`SseService.java`):** Gerenciamento seguro e thread-safe de clientes conectados via `SseEmitter` agrupados por slug de nota. Implementados callbacks de limpeza (`onCompletion`, `onTimeout`, `onError`) para prevenção de memory leaks.
- **Endpoint HTTP Streaming (`NotaController.java`):** Adicionado endpoint `GET /api/v1/notes/{slug}/stream` com `produces = MediaType.TEXT_EVENT_STREAM_VALUE`.
- **Notificação Automática (`UpsertNotaService.java`):** Disparo automático de eventos SSE `nota-update` para clientes inscritos sempre que a nota for criada ou atualizada.
- **Testes Unitários:** Criados `SseServiceTest`, `NotaControllerSseTest` e `UpsertNotaServiceSseTest` (100% dos testes passando).

### 🎨 Frontend (React)
- **Substituição de Polling por `EventSource` nativo:** No componente `Editor` (`frontend/src/pages/Editor/index.tsx`), o loop de requisições HTTP `setInterval` (que gerava respostas `304` e cancelamentos `NS_BINDING_ABORTED`) foi completamente substituído por uma conexão `EventSource` nativa.

---

## Por que?

- Elimina 99% do overhead de requisições HTTP desnecessárias atingindo a API e o banco de dados.
- Elimina cancelamentos de requisições (`NS_BINDING_ABORTED`) no console/DevTools do navegador.
- Proporciona atualizações verdadeiramente instantâneas e em tempo real entre usuários editando a mesma nota.

---

## Como testar?

1. **Testes do Backend:**
   ```bash
   cd backend && ./mvnw test
   ```

2. **Build e Lint do Frontend:**
   ```bash
   cd frontend && npm run lint && npm run build
   ```

3. **Teste em Tempo Real (Duas abas ou navegadores diferentes):**
   - Abra a mesma nota em duas abas (ex: `http://localhost:5173/teste-sse`).
   - Digite em uma aba e observe a outra aba atualizar instantaneamente via SSE sem requisições HTTP em loop no DevTools Network.

---
Closes #37