### PR TITLE
feat: segredo opcional para notas

### DIFF
--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -66,6 +66,11 @@
 		</dependency>
 
 		<dependency>
+			<groupId>org.springframework.security</groupId>
+			<artifactId>spring-security-crypto</artifactId>
+		</dependency>
+
+		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-actuator</artifactId>
 		</dependency>

--- a/backend/src/main/java/br/com/escreveaqui/backend/controllers/NotaController.java
+++ b/backend/src/main/java/br/com/escreveaqui/backend/controllers/NotaController.java
@@ -2,6 +2,8 @@ package br.com.escreveaqui.backend.controllers;
 
 import br.com.escreveaqui.backend.dtos.NotaRequestDTO;
 import br.com.escreveaqui.backend.dtos.NotaResponseDTO;
+import br.com.escreveaqui.backend.exceptions.SegredoInvalidoException;
+import br.com.escreveaqui.backend.services.NotaSecretService;
 import br.com.escreveaqui.backend.services.ReadNotaService;
 import br.com.escreveaqui.backend.services.SseService;
 import br.com.escreveaqui.backend.services.UpsertNotaService;
@@ -18,23 +20,31 @@ import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+
 @RestController
 @RequestMapping("/api/v1/notes")
 @RequiredArgsConstructor
 @Validated
 public class NotaController {
 
+    public static final String SECRET_HEADER = "X-Nota-Secret";
+
     private final ReadNotaService readService;
     private final UpsertNotaService upsertService;
+    private final NotaSecretService secretService;
     private final SseService sseService;
 
     @GetMapping(value = "/{slug}", produces = "application/json")
     public ResponseEntity<NotaResponseDTO> read(
             @PathVariable @Pattern(regexp = SlugUtils.SLUG_REGEX) String slug,
+            @RequestHeader(value = SECRET_HEADER, required = false) String secret,
             HttpServletRequest request,
             HttpServletResponse response
     ) {
-        NotaResponseDTO nota = readService.execute(slug);
+        NotaResponseDTO nota = readService.execute(slug, decodeSecret(secret));
         String etag = "W/\"" + nota.updatedAt().toInstant().toEpochMilli() + "\"";
 
         response.setHeader("ETag", etag);
@@ -47,8 +57,16 @@ public class NotaController {
 
     @GetMapping(value = "/{slug}/stream", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
     public SseEmitter stream(
-            @PathVariable @Pattern(regexp = SlugUtils.SLUG_REGEX) String slug
-    ) {
+            @PathVariable @Pattern(regexp = SlugUtils.SLUG_REGEX) String slug,
+            @RequestParam(required = false) String secret,
+            HttpServletResponse response
+    ) throws IOException {
+        try {
+            secretService.verify(slug, decodeSecret(secret));
+        } catch (SegredoInvalidoException e) {
+            response.sendError(HttpStatus.UNAUTHORIZED.value(), "Nota protegida");
+            return null;
+        }
         return sseService.subscribe(slug);
     }
 
@@ -59,7 +77,18 @@ public class NotaController {
             @RequestBody
             @Valid NotaRequestDTO request
     ) {
-        upsertService.execute(slug, request.content());
+        upsertService.execute(slug, request.content(), request.secret());
         return ResponseEntity.noContent().build();
+    }
+
+    private static String decodeSecret(String encoded) {
+        if (encoded == null || encoded.isBlank()) {
+            return null;
+        }
+        try {
+            return new String(Base64.getDecoder().decode(encoded), StandardCharsets.UTF_8);
+        } catch (IllegalArgumentException e) {
+            return null;
+        }
     }
 }

--- a/backend/src/main/java/br/com/escreveaqui/backend/dtos/NotaRequestDTO.java
+++ b/backend/src/main/java/br/com/escreveaqui/backend/dtos/NotaRequestDTO.java
@@ -4,5 +4,8 @@ import jakarta.validation.constraints.Size;
 
 public record NotaRequestDTO(
         @Size(max = 1000000, message = "Conteúdo muito extenso para Markdown (limite 1MB)")
-        String content
+        String content,
+
+        @Size(max = 128, message = "Segredo muito longo (limite 128 caracteres)")
+        String secret
 ) {}

--- a/backend/src/main/java/br/com/escreveaqui/backend/dtos/NotaResponseDTO.java
+++ b/backend/src/main/java/br/com/escreveaqui/backend/dtos/NotaResponseDTO.java
@@ -5,5 +5,6 @@ import java.time.OffsetDateTime;
 public record NotaResponseDTO(
         String slug,
         String content,
+        boolean hasSecret,
         OffsetDateTime updatedAt
 ) {}

--- a/backend/src/main/java/br/com/escreveaqui/backend/exceptions/SegredoInvalidoException.java
+++ b/backend/src/main/java/br/com/escreveaqui/backend/exceptions/SegredoInvalidoException.java
@@ -1,0 +1,8 @@
+package br.com.escreveaqui.backend.exceptions;
+
+public class SegredoInvalidoException extends RuntimeException {
+
+    public SegredoInvalidoException() {
+        super("Segredo ausente ou incorreto para esta nota.");
+    }
+}

--- a/backend/src/main/java/br/com/escreveaqui/backend/handlers/GlobalExceptionHandler.java
+++ b/backend/src/main/java/br/com/escreveaqui/backend/handlers/GlobalExceptionHandler.java
@@ -1,5 +1,6 @@
 package br.com.escreveaqui.backend.handlers;
 
+import br.com.escreveaqui.backend.exceptions.SegredoInvalidoException;
 import jakarta.validation.ConstraintViolationException;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.dao.DataIntegrityViolationException;
@@ -45,6 +46,16 @@ public class GlobalExceptionHandler {
         return problem;
     }
 
+
+    @ExceptionHandler(SegredoInvalidoException.class)
+    public ProblemDetail handleSegredoInvalido(SegredoInvalidoException ex) {
+        log.warn("Acesso negado a nota protegida");
+
+        ProblemDetail problem = ProblemDetail.forStatus(HttpStatus.UNAUTHORIZED);
+        problem.setTitle("Nota protegida");
+        problem.setDetail(ex.getMessage());
+        return problem;
+    }
 
     @ExceptionHandler(DataIntegrityViolationException.class)
     public ProblemDetail handleDataIntegrity(DataIntegrityViolationException ex) {

--- a/backend/src/main/java/br/com/escreveaqui/backend/models/Nota.java
+++ b/backend/src/main/java/br/com/escreveaqui/backend/models/Nota.java
@@ -7,6 +7,7 @@ public record Nota(
         UUID id,
         String slug,
         String content,
+        String secretHash,
         OffsetDateTime createdAt,
         OffsetDateTime updatedAt
 ) {}

--- a/backend/src/main/java/br/com/escreveaqui/backend/repositories/NotaRepository.java
+++ b/backend/src/main/java/br/com/escreveaqui/backend/repositories/NotaRepository.java
@@ -1,6 +1,7 @@
 package br.com.escreveaqui.backend.repositories;
 
 import br.com.escreveaqui.backend.models.Nota;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.jdbc.core.RowMapper;
 import org.springframework.stereotype.Repository;
@@ -17,6 +18,7 @@ public class NotaRepository {
             rs.getObject("id", UUID.class),
             rs.getString("slug"),
             rs.getString("content"),
+            rs.getString("secret_hash"),
             rs.getObject("created_at", OffsetDateTime.class),
             rs.getObject("updated_at", OffsetDateTime.class)
     );
@@ -27,22 +29,28 @@ public class NotaRepository {
         this.jdbcTemplate = jdbcTemplate;
     }
 
+    @Cacheable("notas")
     public Optional<Nota> findBySlug(String slug) {
         List<Nota> result = jdbcTemplate.query(
-                "SELECT id, slug, content, created_at, updated_at FROM notes WHERE slug = ?",
+                "SELECT id, slug, content, secret_hash, created_at, updated_at FROM notes WHERE slug = ?",
                 NOTA_ROW_MAPPER, slug);
         return result.stream().findFirst();
     }
 
     public boolean upsert(String slug, String content) {
+        return upsert(slug, content, null);
+    }
+
+    public boolean upsert(String slug, String content, String secretHash) {
         return Boolean.TRUE.equals(jdbcTemplate.queryForObject("""
-                INSERT INTO notes (id, slug, content)
-                VALUES (?, ?, ?)
+                INSERT INTO notes (id, slug, content, secret_hash)
+                VALUES (?, ?, ?, ?)
                 ON CONFLICT (slug) DO UPDATE
                     SET content = EXCLUDED.content,
+                        secret_hash = COALESCE(notes.secret_hash, EXCLUDED.secret_hash),
                         updated_at = now()
                 RETURNING (xmax = 0) AS inserted
-                """, Boolean.class, UUID.randomUUID(), slug, content));
+                """, Boolean.class, UUID.randomUUID(), slug, content, secretHash));
     }
 
     public int deleteOldNotes(OffsetDateTime cutoff) {

--- a/backend/src/main/java/br/com/escreveaqui/backend/services/NotaSecretService.java
+++ b/backend/src/main/java/br/com/escreveaqui/backend/services/NotaSecretService.java
@@ -1,0 +1,45 @@
+package br.com.escreveaqui.backend.services;
+
+import br.com.escreveaqui.backend.exceptions.SegredoInvalidoException;
+import br.com.escreveaqui.backend.models.Nota;
+import br.com.escreveaqui.backend.repositories.NotaRepository;
+import br.com.escreveaqui.backend.utils.SlugUtils;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class NotaSecretService {
+
+    /**
+     * BCrypt custo padrão (~100ms por verificação) roda no caminho de cada leitura/escrita
+     * de nota protegida. 
+     * Se o auto-save de 1s pesar, cachear a validação por sessão.
+     */
+    private final PasswordEncoder encoder = new BCryptPasswordEncoder();
+
+    private final NotaRepository notaRepository;
+
+    public String hashOf(String safeSlug) {
+        return notaRepository.findBySlug(safeSlug).map(Nota::secretHash).orElse(null);
+    }
+
+    public void check(String hash, String secret) {
+        if (hash == null) {
+            return;
+        }
+        if (secret == null || !encoder.matches(secret, hash)) {
+            throw new SegredoInvalidoException();
+        }
+    }
+
+    public void verify(String rawSlug, String secret) {
+        check(hashOf(SlugUtils.format(rawSlug)), secret);
+    }
+
+    public String encode(String secret) {
+        return (secret == null || secret.isBlank()) ? null : encoder.encode(secret);
+    }
+}

--- a/backend/src/main/java/br/com/escreveaqui/backend/services/ReadNotaService.java
+++ b/backend/src/main/java/br/com/escreveaqui/backend/services/ReadNotaService.java
@@ -6,7 +6,6 @@ import br.com.escreveaqui.backend.utils.SlugUtils;
 import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.MeterRegistry;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -17,11 +16,13 @@ import java.time.OffsetDateTime;
 public class ReadNotaService {
 
     private final NotaRepository notaRepository;
+    private final NotaSecretService secretService;
     private final Counter hitCounter;
     private final Counter missCounter;
 
-    public ReadNotaService(NotaRepository notaRepository, MeterRegistry registry) {
+    public ReadNotaService(NotaRepository notaRepository, NotaSecretService secretService, MeterRegistry registry) {
         this.notaRepository = notaRepository;
+        this.secretService = secretService;
         this.hitCounter  = Counter.builder("notes.read")
                 .tag("result", "hit")
                 .description("Notas encontradas no banco")
@@ -32,20 +33,24 @@ public class ReadNotaService {
                 .register(registry);
     }
 
-    @Cacheable(value = "notas", key = "T(br.com.escreveaqui.backend.utils.SlugUtils).format(#slug)")
-    @Transactional(readOnly = true)
     public NotaResponseDTO execute(String slug) {
+        return execute(slug, null);
+    }
+
+    @Transactional(readOnly = true)
+    public NotaResponseDTO execute(String slug, String secret) {
         String safeSlug = SlugUtils.format(slug);
         return notaRepository.findBySlug(safeSlug)
                 .map(nota -> {
+                    secretService.check(nota.secretHash(), secret);
                     hitCounter.increment();
                     log.debug("Nota encontrada: slug='{}'", safeSlug);
-                    return new NotaResponseDTO(nota.slug(), nota.content(), nota.updatedAt());
+                    return new NotaResponseDTO(nota.slug(), nota.content(), nota.secretHash() != null, nota.updatedAt());
                 })
                 .orElseGet(() -> {
                     missCounter.increment();
                     log.debug("Nota não encontrada, retornando vazia: slug='{}'", safeSlug);
-                    return new NotaResponseDTO(safeSlug, "", OffsetDateTime.now());
+                    return new NotaResponseDTO(safeSlug, "", false, OffsetDateTime.now());
                 });
     }
 }

--- a/backend/src/main/java/br/com/escreveaqui/backend/services/UpsertNotaService.java
+++ b/backend/src/main/java/br/com/escreveaqui/backend/services/UpsertNotaService.java
@@ -14,12 +14,15 @@ public class UpsertNotaService {
 
     private final NotaRepository notaRepository;
     private final SseService sseService;
+    private final NotaSecretService secretService;
     private final Counter createCounter;
     private final Counter updateCounter;
 
-    public UpsertNotaService(NotaRepository notaRepository, SseService sseService, MeterRegistry registry) {
+    public UpsertNotaService(NotaRepository notaRepository, SseService sseService,
+                             NotaSecretService secretService, MeterRegistry registry) {
         this.notaRepository = notaRepository;
         this.sseService = sseService;
+        this.secretService = secretService;
         this.createCounter = Counter.builder("notes.upsert")
                 .tag("operation", "create")
                 .description("Notas criadas")
@@ -32,9 +35,19 @@ public class UpsertNotaService {
 
     @CacheEvict(value = "notas", key = "T(br.com.escreveaqui.backend.utils.SlugUtils).format(#slug)")
     public void execute(String slug, String content) {
+        execute(slug, content, null);
+    }
+
+    @CacheEvict(value = "notas", key = "T(br.com.escreveaqui.backend.utils.SlugUtils).format(#slug)")
+    public void execute(String slug, String content, String secret) {
         String safeSlug = SlugUtils.format(slug);
 
-        boolean isNew = notaRepository.upsert(safeSlug, content);
+        String currentHash = secretService.hashOf(safeSlug);
+        secretService.check(currentHash, secret);
+
+        String newHash = currentHash == null ? secretService.encode(secret) : null;
+
+        boolean isNew = notaRepository.upsert(safeSlug, content, newHash);
         sseService.notify(safeSlug, content);
 
         if (isNew) createCounter.increment();

--- a/backend/src/main/resources/db/migration/V2__add_secret_hash_to_notes.sql
+++ b/backend/src/main/resources/db/migration/V2__add_secret_hash_to_notes.sql
@@ -1,0 +1,1 @@
+ALTER TABLE notes ADD COLUMN secret_hash TEXT;

--- a/backend/src/test/java/br/com/escreveaqui/backend/controllers/NotaControllerSseTest.java
+++ b/backend/src/test/java/br/com/escreveaqui/backend/controllers/NotaControllerSseTest.java
@@ -1,5 +1,6 @@
 package br.com.escreveaqui.backend.controllers;
 
+import br.com.escreveaqui.backend.services.NotaSecretService;
 import br.com.escreveaqui.backend.services.ReadNotaService;
 import br.com.escreveaqui.backend.services.SseService;
 import br.com.escreveaqui.backend.services.UpsertNotaService;
@@ -31,6 +32,9 @@ class NotaControllerSseTest {
 
     @Mock
     private UpsertNotaService upsertService;
+
+    @Mock
+    private NotaSecretService secretService;
 
     @Mock
     private SseService sseService;

--- a/backend/src/test/java/br/com/escreveaqui/backend/controllers/NotaControllerTest.java
+++ b/backend/src/test/java/br/com/escreveaqui/backend/controllers/NotaControllerTest.java
@@ -1,7 +1,9 @@
 package br.com.escreveaqui.backend.controllers;
 
 import br.com.escreveaqui.backend.dtos.NotaResponseDTO;
+import br.com.escreveaqui.backend.services.NotaSecretService;
 import br.com.escreveaqui.backend.services.ReadNotaService;
+import br.com.escreveaqui.backend.services.SseService;
 import br.com.escreveaqui.backend.services.UpsertNotaService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -35,6 +37,12 @@ class NotaControllerTest {
     @Mock
     private UpsertNotaService upsertService;
 
+    @Mock
+    private NotaSecretService secretService;
+
+    @Mock
+    private SseService sseService;
+
     @InjectMocks
     private NotaController notaController;
 
@@ -48,9 +56,9 @@ class NotaControllerTest {
     void deveRetornarNotaComETag() throws Exception {
         String slug = "minha-nota";
         OffsetDateTime now = OffsetDateTime.now();
-        NotaResponseDTO responseDTO = new NotaResponseDTO(slug, "Texto da nota", now);
+        NotaResponseDTO responseDTO = new NotaResponseDTO(slug, "Texto da nota", false, now);
 
-        when(readService.execute(slug)).thenReturn(responseDTO);
+        when(readService.execute(slug, null)).thenReturn(responseDTO);
 
         mockMvc.perform(get("/api/v1/notes/{slug}", slug))
                 .andExpect(status().isOk())
@@ -59,22 +67,22 @@ class NotaControllerTest {
                 .andExpect(header().exists("ETag"))
                 .andExpect(header().string("Cache-Control", "no-cache"));
 
-        verify(readService).execute(slug);
+        verify(readService).execute(slug, null);
     }
 
     @Test
     @DisplayName("GET /api/v1/notes/{slug} deve repassar o slug para o service de leitura")
     void deveRepassarSlugParaService() throws Exception {
         String rawSlug = "Café & Leite";
-        NotaResponseDTO responseDTO = new NotaResponseDTO("cafe-leite", "Conteúdo", OffsetDateTime.now());
+        NotaResponseDTO responseDTO = new NotaResponseDTO("cafe-leite", "Conteúdo", false, OffsetDateTime.now());
 
-        when(readService.execute(rawSlug)).thenReturn(responseDTO);
+        when(readService.execute(rawSlug, null)).thenReturn(responseDTO);
 
         mockMvc.perform(get("/api/v1/notes/{slug}", rawSlug))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.slug").value("cafe-leite"));
 
-        verify(readService).execute(rawSlug);
+        verify(readService).execute(rawSlug, null);
     }
 
     @Test
@@ -92,6 +100,6 @@ class NotaControllerTest {
                         .content(jsonBody))
                 .andExpect(status().isNoContent());
 
-        verify(upsertService).execute(slug, "Novo conteúdo da nota");
+        verify(upsertService).execute(slug, "Novo conteúdo da nota", null);
     }
 }

--- a/backend/src/test/java/br/com/escreveaqui/backend/services/NotaSecretServiceTest.java
+++ b/backend/src/test/java/br/com/escreveaqui/backend/services/NotaSecretServiceTest.java
@@ -1,0 +1,111 @@
+package br.com.escreveaqui.backend.services;
+
+import br.com.escreveaqui.backend.dtos.NotaResponseDTO;
+import br.com.escreveaqui.backend.exceptions.SegredoInvalidoException;
+import br.com.escreveaqui.backend.models.Nota;
+import br.com.escreveaqui.backend.repositories.NotaRepository;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.OffsetDateTime;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class NotaSecretServiceTest {
+
+    @Mock
+    private NotaRepository notaRepository;
+
+    private NotaSecretService secretService;
+
+    @BeforeEach
+    void setUp() {
+        secretService = new NotaSecretService(notaRepository);
+    }
+
+    private Nota nota(String slug, String hash) {
+        return new Nota(UUID.randomUUID(), slug, "Conteúdo", hash, OffsetDateTime.now(), OffsetDateTime.now());
+    }
+
+    @Test
+    @DisplayName("Nota sem segredo aceita qualquer entrada")
+    void notaSemSegredoAceitaQualquerEntrada() {
+        assertThatCode(() -> secretService.check(null, null)).doesNotThrowAnyException();
+        assertThatCode(() -> secretService.check(null, "qualquer")).doesNotThrowAnyException();
+    }
+
+    @Test
+    @DisplayName("Segredo correto passa, ausente ou errado é rejeitado")
+    void validaSegredoContraHash() {
+        String hash = secretService.encode("minha-senha-ç");
+
+        assertThatCode(() -> secretService.check(hash, "minha-senha-ç")).doesNotThrowAnyException();
+        assertThatThrownBy(() -> secretService.check(hash, "errado")).isInstanceOf(SegredoInvalidoException.class);
+        assertThatThrownBy(() -> secretService.check(hash, null)).isInstanceOf(SegredoInvalidoException.class);
+    }
+
+    @Test
+    @DisplayName("Segredo vazio não vira hash")
+    void segredoVazioNaoViraHash() {
+        assertThat(secretService.encode(null)).isNull();
+        assertThat(secretService.encode("   ")).isNull();
+        assertThat(secretService.encode("ok")).isNotNull();
+    }
+
+    @Test
+    @DisplayName("Leitura de nota protegida exige o segredo correto")
+    void leituraDeNotaProtegidaExigeSegredo() {
+        String hash = secretService.encode("s3cr3t");
+        when(notaRepository.findBySlug("secreta")).thenReturn(Optional.of(nota("secreta", hash)));
+
+        ReadNotaService readService = new ReadNotaService(notaRepository, secretService, new SimpleMeterRegistry());
+
+        assertThatThrownBy(() -> readService.execute("secreta", "errado")).isInstanceOf(SegredoInvalidoException.class);
+
+        NotaResponseDTO ok = readService.execute("secreta", "s3cr3t");
+        assertThat(ok.content()).isEqualTo("Conteúdo");
+        assertThat(ok.hasSecret()).isTrue();
+    }
+
+    @Test
+    @DisplayName("Escrita em nota protegida sem segredo correto não chega ao banco")
+    void escritaEmNotaProtegidaExigeSegredo() {
+        String hash = secretService.encode("s3cr3t");
+        when(notaRepository.findBySlug("secreta")).thenReturn(Optional.of(nota("secreta", hash)));
+
+        UpsertNotaService upsertService = new UpsertNotaService(
+                notaRepository, new SseService(), secretService, new SimpleMeterRegistry());
+
+        assertThatThrownBy(() -> upsertService.execute("secreta", "novo", null))
+                .isInstanceOf(SegredoInvalidoException.class);
+        verify(notaRepository, never()).upsert("secreta", "novo", null);
+    }
+
+    @Test
+    @DisplayName("Segredo é gravado apenas na primeira definição")
+    void segredoGravadoApenasNaPrimeiraDefinicao() {
+        when(notaRepository.findBySlug("nova")).thenReturn(Optional.empty());
+
+        UpsertNotaService upsertService = new UpsertNotaService(
+                notaRepository, new SseService(), secretService, new SimpleMeterRegistry());
+
+        upsertService.execute("nova", "texto", "s3cr3t");
+
+        verify(notaRepository).upsert(org.mockito.ArgumentMatchers.eq("nova"),
+                org.mockito.ArgumentMatchers.eq("texto"),
+                org.mockito.ArgumentMatchers.argThat(h -> h != null && h.startsWith("$2")));
+    }
+}

--- a/backend/src/test/java/br/com/escreveaqui/backend/services/ReadNotaServiceTest.java
+++ b/backend/src/test/java/br/com/escreveaqui/backend/services/ReadNotaServiceTest.java
@@ -32,7 +32,7 @@ class ReadNotaServiceTest {
     @BeforeEach
     void setUp() {
         meterRegistry = new SimpleMeterRegistry();
-        readNotaService = new ReadNotaService(notaRepository, meterRegistry);
+        readNotaService = new ReadNotaService(notaRepository, new NotaSecretService(notaRepository), meterRegistry);
     }
 
     @Test
@@ -40,7 +40,7 @@ class ReadNotaServiceTest {
     void deveBuscarNotaSanitizandoSlug() {
         String rawSlug = "Minha Nota!";
         String sanitizedSlug = "minha-nota";
-        Nota nota = new Nota(UUID.randomUUID(), sanitizedSlug, "Conteúdo da nota", OffsetDateTime.now(), OffsetDateTime.now());
+        Nota nota = new Nota(UUID.randomUUID(), sanitizedSlug, "Conteúdo da nota", null, OffsetDateTime.now(), OffsetDateTime.now());
 
         when(notaRepository.findBySlug(sanitizedSlug)).thenReturn(Optional.of(nota));
 

--- a/backend/src/test/java/br/com/escreveaqui/backend/services/UpsertNotaServiceSseTest.java
+++ b/backend/src/test/java/br/com/escreveaqui/backend/services/UpsertNotaServiceSseTest.java
@@ -28,7 +28,7 @@ class UpsertNotaServiceSseTest {
     @BeforeEach
     void setUp() {
         meterRegistry = new SimpleMeterRegistry();
-        upsertNotaService = new UpsertNotaService(notaRepository, sseService, meterRegistry);
+        upsertNotaService = new UpsertNotaService(notaRepository, sseService, new NotaSecretService(notaRepository), meterRegistry);
     }
 
     @Test
@@ -38,11 +38,11 @@ class UpsertNotaServiceSseTest {
         String sanitizedSlug = "nota-em-tempo-real";
         String content = "Conteudo transmitido via SSE";
 
-        when(notaRepository.upsert(sanitizedSlug, content)).thenReturn(true);
+        when(notaRepository.upsert(sanitizedSlug, content, null)).thenReturn(true);
 
         upsertNotaService.execute(rawSlug, content);
 
-        verify(notaRepository).upsert(sanitizedSlug, content);
+        verify(notaRepository).upsert(sanitizedSlug, content, null);
         verify(sseService).notify(sanitizedSlug, content);
     }
 }

--- a/backend/src/test/java/br/com/escreveaqui/backend/services/UpsertNotaServiceTest.java
+++ b/backend/src/test/java/br/com/escreveaqui/backend/services/UpsertNotaServiceTest.java
@@ -28,7 +28,7 @@ class UpsertNotaServiceTest {
     @BeforeEach
     void setUp() {
         meterRegistry = new SimpleMeterRegistry();
-        upsertNotaService = new UpsertNotaService(notaRepository, sseService, meterRegistry);
+        upsertNotaService = new UpsertNotaService(notaRepository, sseService, new NotaSecretService(notaRepository), meterRegistry);
     }
 
     @Test
@@ -38,11 +38,11 @@ class UpsertNotaServiceTest {
         String sanitizedSlug = "minha-nova-nota";
         String content = "Conteúdo";
 
-        when(notaRepository.upsert(sanitizedSlug, content)).thenReturn(true);
+        when(notaRepository.upsert(sanitizedSlug, content, null)).thenReturn(true);
 
         upsertNotaService.execute(rawSlug, content);
 
-        verify(notaRepository).upsert(sanitizedSlug, content);
+        verify(notaRepository).upsert(sanitizedSlug, content, null);
     }
 
     @Test
@@ -52,10 +52,10 @@ class UpsertNotaServiceTest {
         String sanitizedSlug = "nota-existente";
         String content = "Conteúdo Atualizado";
 
-        when(notaRepository.upsert(sanitizedSlug, content)).thenReturn(false);
+        when(notaRepository.upsert(sanitizedSlug, content, null)).thenReturn(false);
 
         upsertNotaService.execute(rawSlug, content);
 
-        verify(notaRepository).upsert(sanitizedSlug, content);
+        verify(notaRepository).upsert(sanitizedSlug, content, null);
     }
 }

--- a/doc/API.md
+++ b/doc/API.md
@@ -41,12 +41,19 @@ Retorna o conteúdo de uma nota pelo slug.
 |---|---|---|---|
 | `slug` | string | sim | Identificador da nota |
 
+**Cabeçalhos:**
+
+| Cabeçalho | Obrigatório | Descrição |
+|---|---|---|
+| `X-Nota-Secret` | só em nota protegida | Segredo da nota em Base64 (UTF-8) |
+
 **Resposta de sucesso — `200 OK`:**
 
 ```json
 {
   "slug": "minha-nota",
   "content": "Conteúdo da nota aqui.",
+  "hasSecret": false,
   "updatedAt": "2025-04-18T14:30:00Z"
 }
 ```
@@ -80,13 +87,15 @@ Cria ou atualiza uma nota. A operação é idempotente.
 
 ```json
 {
-  "content": "Conteúdo da nota."
+  "content": "Conteúdo da nota.",
+  "secret": "minha-senha"
 }
 ```
 
 | Campo | Tipo | Obrigatório | Limite |
 |---|---|---|---|
 | `content` | string | não | máx. 1.000.000 caracteres (~1 MB) |
+| `secret` | string | só em nota protegida | máx. 128 caracteres |
 
 **Resposta de sucesso — `204 No Content`**
 
@@ -132,6 +141,7 @@ Todos os erros seguem o formato [RFC 9457 (Problem Details)](https://www.rfc-edi
 | Status | Situação |
 |---|---|
 | `400` | Slug inválido ou corpo da requisição fora dos limites |
+| `401` | Nota protegida: segredo ausente ou incorreto |
 | `409` | Conflito de escrita simultânea ou violação de unicidade |
 | `500` | Erro interno inesperado |
 
@@ -174,3 +184,21 @@ curl -X PUT http://localhost:8080/api/v1/notes/minha-nota \
 ```bash
 curl http://localhost:8080/api/v1/notes/minha-nota
 ```
+
+**Ler uma nota protegida:**
+
+```bash
+curl http://localhost:8080/api/v1/notes/minha-nota   -H "X-Nota-Secret: $(printf 'minha-senha' | base64)"
+```
+
+---
+
+## Segredo da Nota
+
+Uma nota pode receber um segredo opcional, útil quando o slug é curto e fácil de adivinhar.
+
+- O segredo é definido na primeira vez que um `PUT` envia o campo `secret`; depois disso ele **não pode ser alterado nem recuperado**.
+- Só o hash BCrypt do segredo é armazenado (coluna `notes.secret_hash`).
+- Enquanto a nota tiver segredo, `GET`, `PUT` e o stream SSE exigem o segredo correto, sob pena de `401 Unauthorized`.
+- `GET /{slug}/stream` recebe o segredo como query param `?secret=` em Base64, porque `EventSource` não envia cabeçalhos.
+- Notas inexistentes continuam retornando `200 OK` com conteúdo vazio, então o `401` só revela que aquele slug já está em uso.

--- a/frontend/src/interface/nota.ts
+++ b/frontend/src/interface/nota.ts
@@ -1,5 +1,6 @@
 export interface Nota {
     slug: string;
     content: string;
+    hasSecret: boolean;
     updatedAt: string; 
 }

--- a/frontend/src/interface/notaRequest.ts
+++ b/frontend/src/interface/notaRequest.ts
@@ -1,3 +1,4 @@
 export interface NotaRequest {
     content: string;
+    secret?: string;
 }

--- a/frontend/src/pages/Editor/index.tsx
+++ b/frontend/src/pages/Editor/index.tsx
@@ -1,17 +1,23 @@
 import { useParams, useNavigate, Link } from "react-router-dom"
-import { useState, useEffect, useRef, useMemo } from "react"
+import { useState, useEffect, useRef, useMemo, type FormEvent } from "react"
+import axios from "axios"
 import { Textarea } from "@/components/ui/textarea"
-import { notaService } from "@/services/notaService"
+import { Input } from "@/components/ui/input"
+import { Button } from "@/components/ui/button"
+import Modal from "@/components/Modal"
+import { notaService, encodeSecret, API_BASE_URL } from "@/services/notaService"
 import { formatSlug } from "@/lib/utils"
 import debounce from "lodash.debounce"
 import type { DebouncedFunc } from "lodash"
-import { Check, LoaderCircle, X } from "lucide-react"
+import { Check, Lock, LockOpen, LoaderCircle, X } from "lucide-react"
 
 const BR_COLORS = ["#009c3b", "#ffdf00", "#002776"]
 const INACTIVITY_TIMEOUT = 2000
 const AUTO_SAVE_DELAY = 1000
 
 type SaveStatus = "idle" | "saving" | "saved" | "error"
+
+const isUnauthorized = (err: unknown) => axios.isAxiosError(err) && err.response?.status === 401
 
 export default function Editor() {
   const { key } = useParams<{ key: string }>()
@@ -21,6 +27,14 @@ export default function Editor() {
   const [caretIndex, setCaretIndex] = useState(0)
   const [saveStatus, setSaveStatus] = useState<SaveStatus>("idle")
   const typingTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+
+  // Segredo opcional da nota: fica só em memória, some ao recarregar a página.
+  const [secret, setSecret] = useState<string | null>(null)
+  const [hasSecret, setHasSecret] = useState(false)
+  const [locked, setLocked] = useState(false)
+  const [secretInput, setSecretInput] = useState("")
+  const [secretError, setSecretError] = useState<string | null>(null)
+  const [isSecretModalOpen, setIsSecretModalOpen] = useState(false)
 
   useEffect(() => {
     if (!key) return
@@ -53,11 +67,17 @@ export default function Editor() {
 
     notaService.getBySlug(key)
       .then((nota) => {
-        if (isMounted && nota?.content !== undefined) {
-          setText(nota.content)
-        }
+        if (!isMounted) return
+        setText(nota.content ?? "")
+        setHasSecret(nota.hasSecret)
       })
       .catch((err) => {
+        if (!isMounted) return
+        if (isUnauthorized(err)) {
+          setHasSecret(true)
+          setLocked(true)
+          return
+        }
         console.error("Erro na busca inicial da nota:", err)
       })
 
@@ -68,11 +88,10 @@ export default function Editor() {
 
   // 2. Conexão SSE para atualizações remotas em tempo real (não resseta ao digitar)
   useEffect(() => {
-    if (!key) return
+    if (!key || locked) return
 
-    const baseUrl = import.meta.env.VITE_API_BASE_URL ?? "http://localhost:8080/api/v1/notes"
-    const sseUrl = `${baseUrl}/${encodeURIComponent(key)}/stream`
-    const eventSource = new EventSource(sseUrl)
+    const query = secret ? `?secret=${encodeURIComponent(encodeSecret(secret))}` : ""
+    const eventSource = new EventSource(`${API_BASE_URL}/${encodeURIComponent(key)}/stream${query}`)
 
     eventSource.addEventListener("nota-update", (event: MessageEvent) => {
       const newContent = event.data
@@ -88,16 +107,17 @@ export default function Editor() {
     return () => {
       eventSource.close()
     }
-  }, [key])
+  }, [key, locked, secret])
 
-  const saveToBackend: DebouncedFunc<(slug: string, content: string) => void> = useMemo(
+  const saveToBackend: DebouncedFunc<(slug: string, content: string, noteSecret: string | null) => void> = useMemo(
     () =>
-      debounce((slug: string, content: string) => {
+      debounce((slug: string, content: string, noteSecret: string | null) => {
         notaService
-          .upsert(slug, content)
+          .upsert(slug, content, noteSecret)
           .then(() => setSaveStatus("saved"))
           .catch((err) => {
             setSaveStatus("error")
+            if (isUnauthorized(err)) setLocked(true)
             console.error("Falha ao salvar no banco:", err)
           })
       }, AUTO_SAVE_DELAY),
@@ -122,7 +142,38 @@ export default function Editor() {
 
     if (key) {
       setSaveStatus("saving")
-      saveToBackend(key, newText)
+      saveToBackend(key, newText, secret)
+    }
+  }
+
+  const handleUnlock = async (e: FormEvent) => {
+    e.preventDefault()
+    if (!key || !secretInput) return
+    setSecretError(null)
+    try {
+      const nota = await notaService.getBySlug(key, secretInput)
+      setText(nota.content ?? "")
+      setHasSecret(nota.hasSecret)
+      setSecret(secretInput)
+      setSecretInput("")
+      setLocked(false)
+    } catch (err) {
+      setSecretError(isUnauthorized(err) ? "Segredo incorreto." : "Não foi possível abrir a nota.")
+    }
+  }
+
+  const handleDefineSecret = async (e: FormEvent) => {
+    e.preventDefault()
+    if (!key || !secretInput) return
+    setSecretError(null)
+    try {
+      await notaService.upsert(key, text, secretInput)
+      setSecret(secretInput)
+      setHasSecret(true)
+      setSecretInput("")
+      setIsSecretModalOpen(false)
+    } catch (err) {
+      setSecretError(isUnauthorized(err) ? "Segredo incorreto." : "Não foi possível definir o segredo.")
     }
   }
 
@@ -142,35 +193,87 @@ export default function Editor() {
     }
   }, [])
 
+  const homeLink = (
+    <Link
+      to="/"
+      className="fixed left-5 top-4 z-10 font-mono text-sm text-foreground/55 hover:text-foreground transition-colors"
+    >
+      escreveaqui.com.br
+    </Link>
+  )
+
+  if (locked) {
+    return (
+      <div className="w-full h-screen bg-background flex items-center justify-center px-4">
+        {homeLink}
+        <form onSubmit={handleUnlock} className="w-full max-w-sm space-y-3">
+          <div className="flex items-center gap-2 font-mono text-sm text-foreground/70">
+            <Lock aria-hidden="true" className="size-4" />
+            Esta nota tem segredo
+          </div>
+          <label htmlFor="note-secret" className="sr-only">
+            Segredo da nota
+          </label>
+          <Input
+            id="note-secret"
+            type="password"
+            autoFocus
+            value={secretInput}
+            onChange={(e) => setSecretInput(e.target.value)}
+            placeholder="Segredo"
+          />
+          {secretError && <p className="text-sm text-destructive">{secretError}</p>}
+          <Button type="submit" className="w-full font-mono">
+            abrir
+          </Button>
+        </form>
+      </div>
+    )
+  }
+
   return (
     <div className="w-full h-screen bg-background">
-      <Link
-        to="/"
-        className="fixed left-5 top-4 z-10 font-mono text-sm text-foreground/55 hover:text-foreground transition-colors"
-      >
-        escreveaqui.com.br
-      </Link>
-      {saveStatus !== "idle" && (
-        <div
-          aria-live="polite"
-          className={`pointer-events-none fixed right-5 top-4 z-10 flex items-center gap-1.5 text-sm ${
-            saveStatus === "error" ? "text-destructive" : "text-foreground/55"
-          }`}
-        >
-          {saveStatus === "saving" ? (
-            <LoaderCircle aria-hidden="true" className="size-4 animate-spin opacity-60" />
-          ) : saveStatus === "saved" ? (
-            <Check aria-hidden="true" className="size-4 stroke-[3] opacity-60" />
-          ) : (
-            <X aria-hidden="true" className="size-4 stroke-[3] opacity-60" />
-          )}
-          {saveStatus === "saving"
-            ? "Salvando…"
-            : saveStatus === "saved"
-              ? "Salvo"
-              : "Erro ao salvar"}
-        </div>
-      )}
+      {homeLink}
+      <div className="fixed right-5 top-4 z-10 flex items-center gap-3">
+        {saveStatus !== "idle" && (
+          <div
+            aria-live="polite"
+            className={`pointer-events-none flex items-center gap-1.5 text-sm ${
+              saveStatus === "error" ? "text-destructive" : "text-foreground/55"
+            }`}
+          >
+            {saveStatus === "saving" ? (
+              <LoaderCircle aria-hidden="true" className="size-4 animate-spin opacity-60" />
+            ) : saveStatus === "saved" ? (
+              <Check aria-hidden="true" className="size-4 stroke-[3] opacity-60" />
+            ) : (
+              <X aria-hidden="true" className="size-4 stroke-[3] opacity-60" />
+            )}
+            {saveStatus === "saving"
+              ? "Salvando…"
+              : saveStatus === "saved"
+                ? "Salvo"
+                : "Erro ao salvar"}
+          </div>
+        )}
+        {hasSecret ? (
+          <Lock aria-label="Nota protegida por segredo" className="size-4 text-foreground/55" />
+        ) : (
+          <button
+            type="button"
+            onClick={() => {
+              setSecretError(null)
+              setSecretInput("")
+              setIsSecretModalOpen(true)
+            }}
+            aria-label="Definir segredo da nota"
+            title="Definir segredo da nota"
+            className="text-foreground/55 hover:text-foreground transition-colors"
+          >
+            <LockOpen aria-hidden="true" className="size-4" />
+          </button>
+        )}
+      </div>
       <Textarea
         value={text}
         onChange={handleChange}
@@ -179,6 +282,34 @@ export default function Editor() {
         className="w-full h-full resize-none border-none rounded-none p-5 pt-14 font-mono text-[18px] leading-6 focus-visible:ring-0 focus-visible:ring-offset-0 placeholder:text-muted-foreground/40 [scrollbar-width:thin] [scrollbar-color:hsl(var(--border))_transparent]"
         style={{ caretColor: BR_COLORS[caretIndex] }}
       />
+
+      <Modal
+        isOpen={isSecretModalOpen}
+        onClose={() => setIsSecretModalOpen(false)}
+        title="Definir segredo"
+      >
+        <form onSubmit={handleDefineSecret} className="space-y-3">
+          <p>
+            Quem não souber o segredo não consegue ler nem editar esta nota. O segredo não pode ser
+            alterado nem recuperado depois.
+          </p>
+          <label htmlFor="new-note-secret" className="sr-only">
+            Novo segredo
+          </label>
+          <Input
+            id="new-note-secret"
+            type="password"
+            maxLength={128}
+            value={secretInput}
+            onChange={(e) => setSecretInput(e.target.value)}
+            placeholder="Segredo"
+          />
+          {secretError && <p className="text-destructive">{secretError}</p>}
+          <Button type="submit" className="w-full font-mono">
+            proteger
+          </Button>
+        </form>
+      </Modal>
     </div>
   )
 }

--- a/frontend/src/pages/Home/index.tsx
+++ b/frontend/src/pages/Home/index.tsx
@@ -92,7 +92,8 @@ export default function Home() {
         <ul>
           <li>Não solicitamos informações pessoais como nome, email ou telefone.</li>
           <li>O conteúdo das notas é armazenado associado apenas à URL que você criou.</li>
-          <li>Qualquer pessoa com acesso à URL da nota poderá ler e editar seu conteúdo.</li>
+          <li>Qualquer pessoa com acesso à URL da nota poderá ler e editar seu conteúdo, a menos que você defina um segredo para ela.</li>
+          <li>O segredo é guardado apenas como hash e não pode ser recuperado se você esquecê-lo.</li>
           <li>Recomendamos não armazenar informações sensíveis (senhas, dados bancários, etc).</li>
         </ul>
       </Modal>

--- a/frontend/src/services/notaService.ts
+++ b/frontend/src/services/notaService.ts
@@ -2,21 +2,31 @@ import axios from 'axios';
 import type { Nota } from '../interface/nota';
 import type { NotaRequest } from '../interface/notaRequest';
 
+export const API_BASE_URL = import.meta.env.VITE_API_BASE_URL ?? 'http://localhost:8080/api/v1/notes';
+
 const api = axios.create({
-    baseURL: import.meta.env.VITE_API_BASE_URL ?? 'http://localhost:8080/api/v1/notes',
+    baseURL: API_BASE_URL,
     headers: {
         'Content-Type': 'application/json',
     }
 });
 
+/** Cabeçalhos HTTP só aceitam ASCII, então o segredo viaja em Base64. */
+export function encodeSecret(secret: string): string {
+    return btoa(String.fromCharCode(...new TextEncoder().encode(secret)));
+}
+
 export const notaService = {
-    async getBySlug(slug: string, signal?: AbortSignal): Promise<Nota> {
-        const response = await api.get<Nota>(`/${slug.trim()}`, { signal });
+    async getBySlug(slug: string, secret?: string | null, signal?: AbortSignal): Promise<Nota> {
+        const response = await api.get<Nota>(`/${slug.trim()}`, {
+            signal,
+            headers: secret ? { 'X-Nota-Secret': encodeSecret(secret) } : undefined,
+        });
         return response.data;
     },
 
-    async upsert(slug: string, content: string): Promise<void> {
-        const payload: NotaRequest = { content };
+    async upsert(slug: string, content: string, secret?: string | null): Promise<void> {
+        const payload: NotaRequest = { content, ...(secret ? { secret } : {}) };
         await api.put(`/${slug.trim()}`, payload);
     }
 };


### PR DESCRIPTION
Closes #50

## O que foi feito?

Fluxo opcional de segredo por nota, sem alterar o comportamento das notas abertas.

**Backend**
- Migration `V2__add_secret_hash_to_notes.sql`: coluna `secret_hash TEXT` nullable.
- `NotaSecretService`: gera e valida o segredo com BCrypt (`spring-security-crypto`). Só o hash é persistido.
- `GET /{slug}`, `PUT /{slug}` e `GET /{slug}/stream` passam a exigir o segredo quando a nota tem hash; caso contrário, `401` em formato Problem Details (`SegredoInvalidoException`).
- Segredo trafega no cabeçalho `X-Nota-Secret` em Base64. No SSE vai como `?secret=`, porque `EventSource` não envia cabeçalhos.
- O segredo é write-once: `COALESCE(notes.secret_hash, EXCLUDED.secret_hash)` no upsert impede que um hash existente seja sobrescrito.
- `NotaResponseDTO` ganhou `hasSecret`, para o frontend saber se deve exibir o cadeado.
- O `@Cacheable` saiu de `ReadNotaService.execute` e foi para `NotaRepository.findBySlug`.

**Frontend**
- Nota protegida renderiza a tela de segredo no lugar do editor; um `401` no auto-save volta a trancá-la.
- Cadeado no canto superior direito: aberto abre o modal "definir segredo", fechado indica nota já protegida.
- O segredo fica apenas em memória — recarregar a página pede o segredo de novo.

**Docs**
- `doc/API.md`: cabeçalho, campo `secret`, status `401`, exemplo com curl e seção "Segredo da Nota".
- Política de Privacidade na Home atualizada.

**Testes**
- `NotaSecretServiceTest` (6 casos): nota sem segredo aceita qualquer entrada, segredo correto/errado/ausente, segredo em branco não vira hash, leitura e escrita de nota protegida, hash gravado só na primeira definição.
- Testes existentes ajustados às novas assinaturas. Suíte: 26 testes.

## Por que?

A issue #50 aponta que os slugs são curtos e adivinháveis, então enumerar rotas encontra notas alheias. O segredo dá uma camada opcional de privacidade sem tocar no fluxo de quem não quer.

Decisões que valem registro:

- **Hash, não texto puro.** Um vazamento de banco não deve entregar os segredos. BCrypt custa ~100ms por verificação, o que também limita brute-force no próprio segredo.
- **Segredo write-once.** Não existe cadastro nem recuperação de conta no projeto; permitir troca de segredo sem prova de posse do antigo seria um caminho para tomar nota alheia, e implementar prova de posse traz complexidade que a issue não pede.
- **Base64 no cabeçalho.** Cabeçalho HTTP só aceita ASCII, e segredo com acento é esperado num projeto brasileiro.
- **Cache movido para o repositório.** Com o `@Cacheable` sobre o DTO, uma leitura autorizada deixaria o conteúdo em cache sob uma chave que só considera o slug; a leitura seguinte, sem segredo, teria cache hit e nunca executaria a validação. Cacheando a linha crua, a verificação roda em toda chamada e a query ao banco continua sendo evitada. Mesmo nome de cache e mesma chave, então o `@CacheEvict` do upsert segue válido.
- **Nota inexistente continua respondendo `200` com conteúdo vazio.** O `401` só revela que aquele slug está em uso — o mesmo que a API já revelava antes.

## Como testar?

```bash
docker compose up -d postgres
cd backend  && DB_PORT=5433 ./mvnw spring-boot:run
cd frontend && npm run dev

DB_PORT=5433 porque o compose publica 5433:5432. O Flyway aplica a V2 sozinho.

Pela interface (http://localhost:5173)

1. Abra /nota-livre, escreva algo e confirme que salva normalmente — comportamento atual, inalterado.
2. Clique no cadeado aberto, defina o segredo minha-senha. O ícone passa a cadeado fechado.
3. Recarregue a página: a tela de segredo aparece no lugar do editor.
4. Digite um segredo errado — "Segredo incorreto." Digite o certo — o conteúdo aparece e volta a salvar.
5. Abra a mesma nota em outra aba com o segredo certo e edite em uma delas: o SSE continua sincronizando.

Pela API

B=http://localhost:8080/api/v1/notes

curl -X PUT $B/teste-segredo -H "Content-Type: application/json" \
  -d '{"content":"conteudo secreto","secret":"minha-senha"}'          # 204

curl -i $B/teste-segredo                                              # 401
curl -i $B/teste-segredo -H "X-Nota-Secret: $(printf 'errada' | base64)"      # 401
curl -i $B/teste-segredo -H "X-Nota-Secret: $(printf 'minha-senha' | base64)" # 200

curl -i -X PUT $B/teste-segredo -H "Content-Type: application/json" \
  -d '{"content":"invadido"}'                                         # 401

curl -i -m 3 "$B/teste-segredo/stream" -H "Accept: text/event-stream" # 401

Suíte

cd backend && ./mvnw test
cd frontend && npx tsc -b --noEmit && npx eslint src && npm run build

Fora do escopo

- Alterar ou remover o segredo de uma nota (exige prova de posse do segredo atual).
- Persistir o segredo entre recarregamentos.
- Rate limit nas respostas 401.
- Cache da verificação BCrypt — marcado com um comentário em NotaSecretService, a ser avaliado se as métricas mostrarem custo.
```

## Prints (se aplicável)

https://github.com/user-attachments/assets/58ddb1a5-b63e-4706-97ba-47570233ec0e
